### PR TITLE
fix(common): Handle ReflectionTypeLoadException in AssemblyTypes

### DIFF
--- a/src/Common/Reflection/AssemblyTypes.cs
+++ b/src/Common/Reflection/AssemblyTypes.cs
@@ -26,23 +26,6 @@ public static class AssemblyTypes
     }
 
     /// <summary>
-    ///     Returns all types from an assembly that can be loaded, gracefully handling
-    ///     <see cref="ReflectionTypeLoadException" /> for assemblies containing types
-    ///     that cannot be resolved (e.g. dynamic proxy assemblies).
-    /// </summary>
-    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
-    {
-        try
-        {
-            return assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException ex)
-        {
-            return ex.Types.Where(static t => t != null)!;
-        }
-    }
-
-    /// <summary>
     ///     Retrieves all types that implement or inherit from the specified generic base type within the provided assemblies.
     /// </summary>
     /// <typeparam name="TBaseType">The generic base type to search for implementations of.</typeparam>
@@ -91,4 +74,22 @@ public static class AssemblyTypes
     /// <returns>A collection of types that implement or inherit from the specified generic base type.</returns>
     public static IEnumerable<Type> GetAppDomainImplementations<TBaseType>(bool concreteOnly = true) =>
         GetImplementations<TBaseType>(concreteOnly, AppDomain.CurrentDomain.GetAssemblies());
+
+    /// <summary>
+    ///     Returns all types from an assembly that can be loaded, gracefully handling
+    ///     <see cref="ReflectionTypeLoadException" /> for assemblies containing types
+    ///     that cannot be resolved (e.g. dynamic proxy assemblies).
+    /// </summary>
+    /// <param name="assembly">The assembly to load types from.</param>
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(static t => t != null)!;
+        }
+    }
 }

--- a/src/Common/Reflection/AssemblyTypes.cs
+++ b/src/Common/Reflection/AssemblyTypes.cs
@@ -20,9 +20,26 @@ public static class AssemblyTypes
     /// <returns>A collection of types that implement or inherit from the specified base type.</returns>
     public static IEnumerable<Type> GetImplementations(Type baseType, bool concreteOnly, params IEnumerable<Assembly> assemblies)
     {
-        return assemblies.Select(assembly => assembly.GetTypes()
+        return assemblies.Select(assembly => GetLoadableTypes(assembly)
                                                      .Where(t => t.IsImplementing(baseType, concreteOnly)))
                          .SelectMany(static t => t);
+    }
+
+    /// <summary>
+    ///     Returns all types from an assembly that can be loaded, gracefully handling
+    ///     <see cref="ReflectionTypeLoadException" /> for assemblies containing types
+    ///     that cannot be resolved (e.g. dynamic proxy assemblies).
+    /// </summary>
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(static t => t != null)!;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## **User description**
## Summary
- Fixed `AssemblyTypes.GetImplementations` throwing `ReflectionTypeLoadException` when scanning assemblies containing unresolvable types (e.g. Castle `DynamicProxyGenAssembly2` from Moq)
- Added `GetLoadableTypes` helper that catches the exception and returns only successfully loaded types — the standard resilient assembly scanning pattern
- This is a **production code fix**, not a test fix — the method should handle partial assembly loads gracefully

## Context
This test failure blocked the 3.0 release pipeline: https://github.com/mrploch/ploch-common/actions/runs/23073367065

## Test plan
- [x] All 11 `AssemblyTypesTests` pass locally
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent AssemblyTypes.GetImplementations from throwing ReflectionTypeLoadException when encountering assemblies with unresolvable types by filtering to loadable types only.


___

## **CodeAnt-AI Description**
**Prevent assembly scanning from throwing when assemblies contain unloadable types**

### What Changed
- Assembly scanning no longer throws ReflectionTypeLoadException when an assembly contains types that cannot be resolved; such unloadable types are skipped and only successfully loaded types are considered
- GetImplementations now returns implementations from the loadable types in each assembly instead of failing the whole scan

### Impact
`✅ Fewer CI build failures due to flaky assembly scans`
`✅ Fewer test flakes when assemblies include dynamic proxy types`
`✅ More resilient startup and discovery of implementations`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of assembly type loading by adding graceful exception handling for reflection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a production issue where AssemblyTypes.GetImplementations was throwing ReflectionTypeLoadException when scanning assemblies containing unresolvable types, such as dynamic proxy assemblies from Moq. The fix introduces a GetLoadableTypes helper method that gracefully handles this exception by filtering to only successfully loaded types, ensuring robust type discovery in complex assembly environments. This change was critical for the 3.0 release pipeline and maintains backward compatibility while improving reliability.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces GetLoadableTypes helper method in AssemblyTypes.cs to catch ReflectionTypeLoadException and return only loadable types</li>

<li>Modifies GetImplementations method to use the new resilient type loading approach instead of direct assembly.GetTypes() calls</li>

<li>Ensures type discovery continues gracefully when encountering assemblies with unresolvable types (e.g., Castle DynamicProxyGenAssembly2)</li>

</ul>
</details>

</div>