### PR TITLE
fix(versioning): Add versionHeightOffset for x.y.0 releases

### DIFF
--- a/src/Common/Reflection/AssemblyTypes.cs
+++ b/src/Common/Reflection/AssemblyTypes.cs
@@ -26,23 +26,6 @@ public static class AssemblyTypes
     }
 
     /// <summary>
-    ///     Returns all types from an assembly that can be loaded, gracefully handling
-    ///     <see cref="ReflectionTypeLoadException" /> for assemblies containing types
-    ///     that cannot be resolved (e.g. dynamic proxy assemblies).
-    /// </summary>
-    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
-    {
-        try
-        {
-            return assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException ex)
-        {
-            return ex.Types.Where(static t => t != null)!;
-        }
-    }
-
-    /// <summary>
     ///     Retrieves all types that implement or inherit from the specified generic base type within the provided assemblies.
     /// </summary>
     /// <typeparam name="TBaseType">The generic base type to search for implementations of.</typeparam>
@@ -91,4 +74,22 @@ public static class AssemblyTypes
     /// <returns>A collection of types that implement or inherit from the specified generic base type.</returns>
     public static IEnumerable<Type> GetAppDomainImplementations<TBaseType>(bool concreteOnly = true) =>
         GetImplementations<TBaseType>(concreteOnly, AppDomain.CurrentDomain.GetAssemblies());
+
+    /// <summary>
+    ///     Returns all types from an assembly that can be loaded, gracefully handling
+    ///     <see cref="ReflectionTypeLoadException" /> for assemblies containing types
+    ///     that cannot be resolved (e.g. dynamic proxy assemblies).
+    /// </summary>
+    /// <param name="assembly">The assembly to load types from.</param>
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(static t => t != null)!;
+        }
+    }
 }

--- a/src/Common/Reflection/AssemblyTypes.cs
+++ b/src/Common/Reflection/AssemblyTypes.cs
@@ -20,9 +20,26 @@ public static class AssemblyTypes
     /// <returns>A collection of types that implement or inherit from the specified base type.</returns>
     public static IEnumerable<Type> GetImplementations(Type baseType, bool concreteOnly, params IEnumerable<Assembly> assemblies)
     {
-        return assemblies.Select(assembly => assembly.GetTypes()
+        return assemblies.Select(assembly => GetLoadableTypes(assembly)
                                                      .Where(t => t.IsImplementing(baseType, concreteOnly)))
                          .SelectMany(static t => t);
+    }
+
+    /// <summary>
+    ///     Returns all types from an assembly that can be loaded, gracefully handling
+    ///     <see cref="ReflectionTypeLoadException" /> for assemblies containing types
+    ///     that cannot be resolved (e.g. dynamic proxy assemblies).
+    /// </summary>
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(static t => t != null)!;
+        }
     }
 
     /// <summary>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.1-prerelease",
+  "versionHeightOffset": -1,
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
## **User description**
## Summary
- Added `"versionHeightOffset": -1` to `version.json` so that the release workflow produces `x.y.0` versions instead of `x.y.1`
- **Root cause:** NBGV counts the commit that *contains* the version.json change as height 1, so the release workflow (which commits a version change then reads the version) always got `x.y.1`
- Cleaned up orphaned tag `v3.0.1` from the failed release attempt

## Also needed before next release attempt
- **Update `NUGET_API_KEY` secret** — the current key was last updated 2023-06-30 and returned 403 Forbidden

## Test plan
- [ ] Merge this PR
- [ ] Update `NUGET_API_KEY` in repo secrets
- [ ] Trigger Release workflow with `release_version: 3.0`
- [ ] Verify NuGet package version is `3.0.0` (not `3.0.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Configure version.json with a version height offset to align NBGV-generated release versions with expected x.y.0 semantics.


___

## **CodeAnt-AI Description**
Ensure release workflow publishes x.y.0 package versions

### What Changed
- Release metadata now offsets version height so releases produce x.y.0 instead of x.y.1
- The first release commit after a version bump yields the expected patch zero package version

### Impact
`✅ NuGet packages published as x.y.0 instead of x.y.1`
`✅ Fewer failed or unexpected release versions`
`✅ More predictable release numbering`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
