### PR TITLE
ci(workflows): Add PR package versioning and publish to GitHub Packages

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -54,6 +54,11 @@ jobs:
           BASE=$(echo "$CURRENT_VERSION" | cut -d. -f1-2)
           # Override the prerelease tag to include PR number and branch name
           dotnet nbgv set-version "${BASE}-pr.${PR_NUMBER}.${SANITIZED}"
+          # NBGV reads version.json from the committed git state, so we must
+          # commit the change for it to take effect. This ephemeral commit is
+          # never pushed — it only exists on the CI runner.
+          git add version.json
+          git -c user.name="ci" -c user.email="ci@ci" commit -m "ci: PR version" --no-verify
           COMPUTED=$(dotnet nbgv get-version --variable NuGetPackageVersion)
           echo "PR NuGet package version: $COMPUTED"
 

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -39,6 +39,24 @@ jobs:
       - name: Restore .NET tools
         run: dotnet tool restore
 
+      # For PR builds, embed the PR number and branch name in the prerelease tag
+      # so packages are clearly identifiable (e.g. 3.1.1-pr.42.fix-serialization)
+      - name: Configure PR package version
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          # Sanitize branch name for NuGet SemVer2 prerelease identifiers [a-zA-Z0-9-]
+          SANITIZED=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-20 | sed 's/-$//')
+          # Read current major.minor from NBGV
+          CURRENT_VERSION=$(dotnet nbgv get-version --variable SimpleVersion)
+          BASE=$(echo "$CURRENT_VERSION" | cut -d. -f1-2)
+          # Override the prerelease tag to include PR number and branch name
+          dotnet nbgv set-version "${BASE}-pr.${PR_NUMBER}.${SANITIZED}"
+          COMPUTED=$(dotnet nbgv get-version --variable NuGetPackageVersion)
+          echo "PR NuGet package version: $COMPUTED"
+
       # Restore
       - name: Restore dependencies
         run: dotnet restore ./Ploch.Common.slnx
@@ -67,10 +85,9 @@ jobs:
 
       # Build and Test (always runs regardless of SonarCloud status)
       - name: Build
-        run: dotnet build ./Ploch.Common.slnx --no-restore
+        run: dotnet build ./Ploch.Common.slnx --no-restore -c Release
       - name: Test
-        run: dotnet test ./Ploch.Common.slnx --verbosity normal --no-build --logger "trx;LogFileName=TestOutputResults.trx" /p:CollectCoverage=true /p:CoverletOutput=./CoverageResults/ "/p:CoverletOutputFormat=cobertura%2copencover"
-        continue-on-error: true
+        run: dotnet test ./Ploch.Common.slnx --verbosity normal --no-build -c Release --logger "trx;LogFileName=TestOutputResults.trx" /p:CollectCoverage=true /p:CoverletOutput=./CoverageResults/ "/p:CoverletOutputFormat=cobertura%2copencover"
 
       # SonarCloud end (runs even after test failures, only if begin succeeded)
       - name: SonarScanner End
@@ -125,14 +142,29 @@ jobs:
       # Publish prerelease NuGet packages to GitHub Packages
       # Release packages are published to nuget.org via the release workflow
       - name: Add GitHub Packages source
-        if: always()
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
         run: dotnet nuget add source --username kploch --password "$GH_PACKAGES_TOKEN" --store-password-in-clear-text --name github "https://nuget.pkg.github.com/mrploch/index.json"
       - name: Publish NuGet packages to GitHub Packages
-        if: always()
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
         run: |
+          dotnet nuget push ./**/*.nupkg --source github --skip-duplicate -k "$GH_PACKAGES_TOKEN"
+          dotnet nuget push ./**/*.snupkg --source github --skip-duplicate -k "$GH_PACKAGES_TOKEN" || true
+
+      # Publish PR packages to GitHub Packages for testing/validation
+      # PR packages include branch name in the prerelease tag (configured above)
+      - name: Publish PR packages to GitHub Packages
+        if: success() && github.event_name == 'pull_request'
+        env:
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+        run: |
+          if [ -z "$GH_PACKAGES_TOKEN" ]; then
+            echo "::warning::GH_PACKAGES_TOKEN not available, skipping PR package publish"
+            exit 0
+          fi
+          dotnet nuget add source --username kploch --password "$GH_PACKAGES_TOKEN" --store-password-in-clear-text --name github "https://nuget.pkg.github.com/mrploch/index.json"
           dotnet nuget push ./**/*.nupkg --source github --skip-duplicate -k "$GH_PACKAGES_TOKEN"
           dotnet nuget push ./**/*.snupkg --source github --skip-duplicate -k "$GH_PACKAGES_TOKEN" || true

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -49,6 +49,13 @@ jobs:
         run: |
           # Sanitize branch name for NuGet SemVer2 prerelease identifiers [a-zA-Z0-9-]
           SANITIZED=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-20 | sed 's/-$//')
+          # Guard against empty or purely-numeric identifiers (invalid in SemVer2)
+          if [ -z "$SANITIZED" ]; then
+            SANITIZED="branch"
+          fi
+          if echo "$SANITIZED" | grep -Eq '^[0-9]+$'; then
+            SANITIZED="b-${SANITIZED}"
+          fi
           # Read current major.minor from NBGV
           CURRENT_VERSION=$(dotnet nbgv get-version --variable SimpleVersion)
           BASE=$(echo "$CURRENT_VERSION" | cut -d. -f1-2)
@@ -141,6 +148,7 @@ jobs:
       - name: Deploy GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/master' && steps.docfx.outcome == 'success'
+        continue-on-error: true
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: ./DocumentationSite/_site

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,13 @@ jobs:
           dotnet nbgv set-version "$RELEASE_VERSION"
           echo "Release version set to $RELEASE_VERSION"
 
-      # Idempotent commit: only commit if version.json actually changed
+      # Use the current HEAD commit timestamp so reruns recreate the same
+      # release commit SHA until the release branch state changes.
       - name: Commit release version
         run: |
+          RELEASE_COMMIT_TIMESTAMP=$(git show -s --format=%cI HEAD)
+          export GIT_AUTHOR_DATE="$RELEASE_COMMIT_TIMESTAMP"
+          export GIT_COMMITTER_DATE="$RELEASE_COMMIT_TIMESTAMP"
           git add version.json
           git diff --cached --quiet && echo "version.json unchanged, skipping commit" || \
             git commit -m "chore(release): Set version to $RELEASE_VERSION"
@@ -208,6 +212,16 @@ jobs:
           \`\`\`
           ENDOFNOTES
 
+      - name: Create GitHub Release
+        if: success()
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: "Release ${{ steps.version.outputs.nuget_version }}"
+          body_path: /tmp/release-notes.md
+          draft: false
+          prerelease: false
+
       - name: Compute next development version
         id: next
         if: success()
@@ -247,13 +261,3 @@ jobs:
           git diff --cached --quiet && echo "No changes to commit" || \
             git commit -m "chore(release): Bump version to ${NEXT_DEV_VERSION}-prerelease for development"
           git push origin master
-
-      - name: Create GitHub Release
-        if: success()
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          name: "Release ${{ steps.version.outputs.nuget_version }}"
-          body_path: /tmp/release-notes.md
-          draft: false
-          prerelease: false

--- a/change-log/2026-03-15-ci-pr-package-versioning.md
+++ b/change-log/2026-03-15-ci-pr-package-versioning.md
@@ -1,0 +1,7 @@
+## CI: PR package versioning and publishing
+
+- **PR builds** now publish NuGet packages to GitHub Packages with a branch-identifying prerelease tag (e.g. `3.1.1-pr.42.fix-serialization`), making it easy to test packages from in-progress work.
+- **Master push builds** continue to publish prerelease packages (`3.1.1-prerelease`) to GitHub Packages only.
+- **Release builds** continue to publish stable packages to NuGet.org via the manual release workflow.
+- Build and test steps now consistently use Release configuration.
+- Release workflow: GitHub Release is now created before the version bump commit, and the release commit uses deterministic timestamps for idempotent reruns.

--- a/change-log/2026-03-15-ci-pr-package-versioning.md
+++ b/change-log/2026-03-15-ci-pr-package-versioning.md
@@ -2,6 +2,6 @@
 
 - **PR builds** now publish NuGet packages to GitHub Packages with a branch-identifying prerelease tag (e.g. `3.1.1-pr.42.fix-serialization`), making it easy to test packages from in-progress work.
 - **Master push builds** continue to publish prerelease packages (`3.1.1-prerelease`) to GitHub Packages only.
-- **Release builds** continue to publish stable packages to NuGet.org via the manual release workflow.
+- **Release builds** continue to publish stable packages (e.g. `3.1.0`) to NuGet.org via the manual release workflow.
 - Build and test steps now consistently use Release configuration.
 - Release workflow: GitHub Release is now created before the version bump commit, and the release commit uses deterministic timestamps for idempotent reruns.

--- a/change-log/2026-03-23-fix-isin-extensions.md
+++ b/change-log/2026-03-23-fix-isin-extensions.md
@@ -1,0 +1,5 @@
+## Fix: IsInExtensions equality check and null guard
+
+- **Bug fix:** `In` and `NotIn` extension methods now correctly match default values (e.g. `0`, `null`) by using `EqualityComparer<TValue?>.Default.Equals` instead of the previous `value.Equals(v)` approach which skipped default values.
+- **Null guard:** Added `comparer.NotNull()` validation for `IComparer`-based overloads to fail fast with `ArgumentNullException` instead of `NullReferenceException`.
+- **Test coverage:** Added comprehensive tests for enum values, `IEnumerable` overloads, `IComparer` overloads, and `NotIn` variants.

--- a/src/Common/IsInExtensions.cs
+++ b/src/Common/IsInExtensions.cs
@@ -19,7 +19,7 @@ public static class IsInExtensions
     ///     <c>true</c> if the <paramref name="value" /> is equal to one of the <paramref name="values" />, <c>false</c>
     ///     otherwise.
     /// </returns>
-    public static bool In<TValue>(this TValue value, params TValue[] values) => In(value, (IEnumerable<TValue>)values);
+    public static bool In<TValue>(this TValue value, params TValue[] values) => value.In((IEnumerable<TValue>)values);
 
     /// <summary>
     ///     Checks if the <paramref name="value" /> is equal to one of the <paramref name="values" /> provided.
@@ -35,7 +35,7 @@ public static class IsInExtensions
     {
         values.NotNull(nameof(values));
 
-        return values.Any(v => value.IsNotDefault() && value!.Equals(v));
+        return values.Any(v => EqualityComparer<TValue?>.Default.Equals(value, v));
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public static class IsInExtensions
     ///     <c>true</c> if the <paramref name="value" /> is equal to one of the <paramref name="values" /> according to the <paramref name="comparer" />, <c>false</c>
     ///     otherwise.
     /// </returns>
-    public static bool In<TValue>(this TValue? value, IComparer<TValue?> comparer, params TValue[] values) => In(value, comparer, (IEnumerable<TValue>)values);
+    public static bool In<TValue>(this TValue? value, IComparer<TValue?> comparer, params TValue[] values) => value.In(comparer, (IEnumerable<TValue>)values);
 
     /// <summary>
     ///     Checks if the <paramref name="value" /> is equal to one of the <paramref name="values" /> provided using the specified comparer.
@@ -79,7 +79,7 @@ public static class IsInExtensions
     ///     <c>true</c> if the <paramref name="value" /> is equal to one of the <paramref name="values" />, <c>false</c>
     ///     otherwise.
     /// </returns>
-    public static bool NotIn<TValue>(this TValue value, params TValue[] values) => NotIn(value, (IEnumerable<TValue>)values);
+    public static bool NotIn<TValue>(this TValue value, params TValue[] values) => value.NotIn((IEnumerable<TValue>)values);
 
     /// <summary>
     ///     Checks if the <paramref name="value" /> is equal to one of the <paramref name="values" /> provided.
@@ -91,7 +91,7 @@ public static class IsInExtensions
     ///     <c>true</c> if the <paramref name="value" /> is equal to one of the <paramref name="values" />, <c>false</c>
     ///     otherwise.
     /// </returns>
-    public static bool NotIn<TValue>(this TValue value, IEnumerable<TValue> values) => !In(value, values);
+    public static bool NotIn<TValue>(this TValue value, IEnumerable<TValue> values) => !value.In(values);
 
     /// <summary>
     ///     Checks if the <paramref name="value" /> is not equal to any of the <paramref name="values" /> provided using the specified comparer.
@@ -105,7 +105,7 @@ public static class IsInExtensions
     ///     <c>false</c> otherwise.
     /// </returns>
     public static bool NotIn<TValue>(this TValue? value, IComparer<TValue?> comparer, params TValue[] values) =>
-        NotIn(value, comparer, (IEnumerable<TValue>)values);
+        value.NotIn(comparer, (IEnumerable<TValue>)values);
 
     /// <summary>
     ///     Checks if the <paramref name="value" /> is not equal to any of the <paramref name="values" /> provided using the specified comparer.
@@ -119,5 +119,5 @@ public static class IsInExtensions
     ///     <c>false</c>
     ///     otherwise.
     /// </returns>
-    public static bool NotIn<TValue>(this TValue? value, IComparer<TValue?> comparer, IEnumerable<TValue?> values) => !In(value, comparer, values);
+    public static bool NotIn<TValue>(this TValue? value, IComparer<TValue?> comparer, IEnumerable<TValue?> values) => !value.In(comparer, values);
 }

--- a/src/Common/IsInExtensions.cs
+++ b/src/Common/IsInExtensions.cs
@@ -64,7 +64,7 @@ public static class IsInExtensions
     /// </returns>
     public static bool In<TValue>(this TValue? value, IComparer<TValue?> comparer, IEnumerable<TValue?> values)
     {
-        comparer.NotNull(nameof(comparer));
+        _ = comparer.NotNull(nameof(comparer));
         values.NotNull(nameof(values));
 
         return values.Any(v => comparer.Compare(v, value) == 0);

--- a/src/Common/IsInExtensions.cs
+++ b/src/Common/IsInExtensions.cs
@@ -64,6 +64,7 @@ public static class IsInExtensions
     /// </returns>
     public static bool In<TValue>(this TValue? value, IComparer<TValue?> comparer, IEnumerable<TValue?> values)
     {
+        comparer.NotNull(nameof(comparer));
         values.NotNull(nameof(values));
 
         return values.Any(v => comparer.Compare(v, value) == 0);

--- a/tests/Common.Tests/IsInExtensionsTests.cs
+++ b/tests/Common.Tests/IsInExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using Ploch.Common.Tests.TestTypes.TestingTypes;
 
 namespace Ploch.Common.Tests;
 
@@ -65,5 +66,60 @@ public class IsInExtensionsTests
                                                                                                            params string?[] strings)
     {
         value.In(IgnoringSymbolsComparer, strings).Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void In_should_return_true_if_enum_is_in_the_list()
+    {
+        TestEnum.FirstValue.In(TestEnum.FirstValue, TestEnum.SecondValue).Should().BeTrue();
+        var bool1 = TestEnum.FirstValue.In(TestEnum.FirstValue, TestEnum.SecondValue);
+        var bool2 = TestEnum.ThirdValue.In(TestEnum.FirstValue, TestEnum.SecondValue);
+        Console.WriteLine(bool1);
+        Console.WriteLine(bool2);
+    }
+
+    [Fact]
+    public void In_should_return_false_if_enum_is_not_in_the_list()
+    {
+        TestEnum.ThirdValue.In(TestEnum.FirstValue, TestEnum.SecondValue).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("test", false, "t1", "t2", "test")]
+    [InlineData("test", false, "t1", "t2", "TeSt")]
+    [InlineData("test", false, null, null, null, null, "test")]
+    [InlineData(null, false, "t1", "t2", "t3", null, "t4")]
+    [InlineData("test", true, "t1", "t2", "t3")]
+    [InlineData("test", true, "t1", "t2", "Te_St")]
+    [InlineData("", true, "t1", "t2", "t3", null, "t4")]
+    public void NotIn_should_return_if_matching_string_is_not_found_with_case_insensitive_matching(string? value, bool expectedResult, params string?[] strings)
+    {
+        value.NotIn(StringComparer.OrdinalIgnoreCase, strings).Should().Be(expectedResult);
+    }
+
+    [Theory]
+    [InlineData("test", false, "t1", "t2", "te!st")]
+    [InlineData("test", true, "t1", "t2", "TeSt")]
+    [InlineData("test", false, null, null, null, null, "te%st")]
+    [InlineData(null, false, "t1", "t2", "t3", null, "t4")]
+    [InlineData("test", true, "t1", "t2", "t3")]
+    [InlineData("", true, "t1", "t2", "t3", null, "t4")]
+    public void NotIn_should_return_if_matching_string_is_not_found_with_case_sensitive_ignoring_symbols_matching(string? value,
+                                                                                                                  bool expectedResult,
+                                                                                                                  params string?[] strings)
+    {
+        value.NotIn(IgnoringSymbolsComparer, strings).Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void NotIn_should_return_false_if_enum_is_in_the_list()
+    {
+        TestEnum.FirstValue.NotIn(TestEnum.FirstValue, TestEnum.SecondValue).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NotIn_should_return_true_if_enum_is_not_in_the_list()
+    {
+        TestEnum.ThirdValue.NotIn(TestEnum.FirstValue, TestEnum.SecondValue).Should().BeTrue();
     }
 }

--- a/tests/Common.Tests/IsInExtensionsTests.cs
+++ b/tests/Common.Tests/IsInExtensionsTests.cs
@@ -68,20 +68,12 @@ public class IsInExtensionsTests
         value.In(IgnoringSymbolsComparer, strings).Should().Be(expectedResult);
     }
 
-    [Fact]
-    public void In_should_return_true_if_enum_is_in_the_list()
+    [Theory]
+    [InlineData(TestEnum.FirstValue, true)]
+    [InlineData(TestEnum.ThirdValue, false)]
+    public void In_should_return_expected_result_for_enum_values(TestEnum value, bool expectedResult)
     {
-        TestEnum.FirstValue.In(TestEnum.FirstValue, TestEnum.SecondValue).Should().BeTrue();
-        var bool1 = TestEnum.FirstValue.In(TestEnum.FirstValue, TestEnum.SecondValue);
-        var bool2 = TestEnum.ThirdValue.In(TestEnum.FirstValue, TestEnum.SecondValue);
-        Console.WriteLine(bool1);
-        Console.WriteLine(bool2);
-    }
-
-    [Fact]
-    public void In_should_return_false_if_enum_is_not_in_the_list()
-    {
-        TestEnum.ThirdValue.In(TestEnum.FirstValue, TestEnum.SecondValue).Should().BeFalse();
+        value.In(TestEnum.FirstValue, TestEnum.SecondValue).Should().Be(expectedResult);
     }
 
     [Theory]
@@ -111,16 +103,12 @@ public class IsInExtensionsTests
         value.NotIn(IgnoringSymbolsComparer, strings).Should().Be(expectedResult);
     }
 
-    [Fact]
-    public void NotIn_should_return_false_if_enum_is_in_the_list()
+    [Theory]
+    [InlineData(TestEnum.FirstValue, false)]
+    [InlineData(TestEnum.ThirdValue, true)]
+    public void NotIn_should_return_expected_result_for_enum_values(TestEnum value, bool expectedResult)
     {
-        TestEnum.FirstValue.NotIn(TestEnum.FirstValue, TestEnum.SecondValue).Should().BeFalse();
-    }
-
-    [Fact]
-    public void NotIn_should_return_true_if_enum_is_not_in_the_list()
-    {
-        TestEnum.ThirdValue.NotIn(TestEnum.FirstValue, TestEnum.SecondValue).Should().BeTrue();
+        value.NotIn(TestEnum.FirstValue, TestEnum.SecondValue).Should().Be(expectedResult);
     }
 
     [Fact]

--- a/tests/Common.Tests/IsInExtensionsTests.cs
+++ b/tests/Common.Tests/IsInExtensionsTests.cs
@@ -122,4 +122,67 @@ public class IsInExtensionsTests
     {
         TestEnum.ThirdValue.NotIn(TestEnum.FirstValue, TestEnum.SecondValue).Should().BeTrue();
     }
+
+    [Fact]
+    public void In_with_IEnumerable_should_return_true_if_value_is_in_the_list()
+    {
+        var values = new List<string> { "t1", "t2", "test" };
+        "test".In(values).Should().BeTrue();
+    }
+
+    [Fact]
+    public void In_with_IEnumerable_should_return_false_if_value_is_not_in_the_list()
+    {
+        var values = new List<string> { "t1", "t2" };
+        "test".In(values).Should().BeFalse();
+    }
+
+    [Fact]
+    public void In_with_IEnumerable_should_handle_null_values()
+    {
+        var values = new List<string?> { "t1", null, "t2" };
+        ((string?)null).In(values).Should().BeTrue();
+    }
+
+    [Fact]
+    public void NotIn_with_IEnumerable_should_return_true_if_value_is_not_in_the_list()
+    {
+        var values = new List<string> { "t1", "t2" };
+        "test".NotIn(values).Should().BeTrue();
+    }
+
+    [Fact]
+    public void NotIn_with_IEnumerable_should_return_false_if_value_is_in_the_list()
+    {
+        var values = new List<string> { "t1", "t2", "test" };
+        "test".NotIn(values).Should().BeFalse();
+    }
+
+    [Fact]
+    public void In_with_IComparer_and_IEnumerable_should_return_true_if_matching_value_is_found()
+    {
+        var values = new List<string> { "t1", "t2", "TeSt" };
+        "test".In(StringComparer.OrdinalIgnoreCase, values).Should().BeTrue();
+    }
+
+    [Fact]
+    public void In_with_IComparer_and_IEnumerable_should_return_false_if_matching_value_is_not_found()
+    {
+        var values = new List<string> { "t1", "t2", "t3" };
+        "test".In(StringComparer.OrdinalIgnoreCase, values).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NotIn_with_IComparer_and_IEnumerable_should_return_true_if_matching_value_is_not_found()
+    {
+        var values = new List<string> { "t1", "t2", "t3" };
+        "test".NotIn(StringComparer.OrdinalIgnoreCase, values).Should().BeTrue();
+    }
+
+    [Fact]
+    public void NotIn_with_IComparer_and_IEnumerable_should_return_false_if_matching_value_is_found()
+    {
+        var values = new List<string> { "t1", "t2", "TeSt" };
+        "test".NotIn(StringComparer.OrdinalIgnoreCase, values).Should().BeFalse();
+    }
 }


### PR DESCRIPTION
## **User description**
## Describe your changes

### CI: PR package versioning and publishing

- **PR builds** now produce NuGet packages with branch-identifying prerelease tags (e.g. `3.1.1-pr.42.fix-serialization`) and publish them to GitHub Packages
- **Master push builds** continue publishing prerelease packages (`3.1.1-prerelease`) to GitHub Packages only — unchanged
- **Release builds** continue publishing stable packages to NuGet.org — unchanged
- Build and test steps now consistently use Release configuration
- Master publish condition tightened (was `always()`, now gated on push + master)
- GitHub Pages deployment failure no longer blocks package publishing (`continue-on-error: true`)
- Release workflow: creates GitHub Release before the version bump commit for idempotent reruns with deterministic timestamps

#### Version matrix

| Scenario | Example Version | Published To |
|----------|----------------|-------------|
| PR build | `3.1.2-pr.187.fix-serialization` | GitHub Packages |
| Master push | `3.1.2-prerelease` | GitHub Packages |
| Release | `3.1.0` | NuGet.org |

### Fix: IsInExtensions equality check and null guard

- **Bug fix:** `In` and `NotIn` extension methods now correctly match default values (e.g. `0`, `null`) by using `EqualityComparer<TValue?>.Default.Equals` instead of `value.Equals(v)` which skipped default values
- **Null guard:** Added `comparer.NotNull()` validation for `IComparer`-based overloads
- **Refactor:** Changed static method calls to extension method syntax for consistency
- **Test coverage:** Added comprehensive tests for enum values, `IEnumerable` overloads, `IComparer` overloads, and `NotIn` variants

### How PR versioning works

For PR builds, the workflow:
1. Reads the current NBGV base version (e.g. `3.1`)
2. Sanitises the branch name for NuGet SemVer2 compatibility
3. Guards against empty/numeric-only sanitised identifiers
4. Calls `dotnet nbgv set-version` to embed PR number + branch name in the prerelease tag
5. Builds and publishes packages to GitHub Packages

## Issue ticket number and link

N/A — infrastructure improvement and bug fix

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? — N/A
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
  - CI: PR builds now publish testable NuGet packages to GitHub Packages
  - Fix: `In`/`NotIn` extension methods now correctly handle default values and null comparers

## No breaking changes

All public API signatures remain unchanged. The `IsInExtensions` equality fix corrects behaviour (default values now match correctly), which is a bug fix rather than a breaking change.


___

## **CodeAnt-AI Description**
**Publish branch-specific PR packages and fix matching for default values**

### What Changed
- PR builds now publish NuGet packages to GitHub Packages with a branch- and PR-specific prerelease label, making preview packages easy to identify and test.
- Build and test runs now use Release settings, and master publishing only runs on master push builds.
- If GitHub Pages deployment fails, package publishing can still continue.
- Release runs now create the GitHub Release before the follow-up version bump, and release commits use a stable timestamp for repeatable reruns.
- `In` and `NotIn` now handle `null`, `0`, and other default values correctly, and comparer-based checks fail fast when no comparer is provided.
- Added test coverage for enum values, list-based checks, comparer-based checks, and `NotIn` cases.

### Impact
`✅ Easier testing of PR packages`
`✅ Fewer release publishing interruptions`
`✅ Correct matching for null and zero values`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
