### PR TITLE
ci(qodana): Align linter with action CLI version

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
       checks: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2025.2
+        uses: JetBrains/qodana-action@v2025.3.2
         with:
           pr-mode: false
         env:

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Clone mrploch-development (shared build config)
         run: git clone --depth 1 https://github.com/mrploch/mrploch-development.git ../mrploch-development
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2025.3.1
+        uses: JetBrains/qodana-action@v2025.2
         with:
           pr-mode: false
           args: --baseline,qodana.sarif.json,--solution,Ploch.Common.slnx

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Clone mrploch-development (shared build config)
         run: git clone --depth 1 https://github.com/mrploch/mrploch-development.git ../mrploch-development
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2025.2
+        uses: JetBrains/qodana-action@v2025.3.2
         with:
           pr-mode: false
           args: --baseline,qodana.sarif.json,--solution,Ploch.Common.slnx

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: "1.0"
-linter: jetbrains/qodana-cdnet:2025.2-eap
+linter: jetbrains/qodana-cdnet:2025.3-eap
 bootstrap: |
   git clone --depth 1 https://github.com/mrploch/mrploch-development.git /data/mrploch-development
 profile:

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: "1.0"
-linter: jetbrains/qodana-cdnet:2025.2
+linter: jetbrains/qodana-cdnet:2025.2-eap
 bootstrap: |
   git clone --depth 1 https://github.com/mrploch/mrploch-development.git /data/mrploch-development
 profile:

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: "1.0"
-linter: jetbrains/qodana-cdnet:2025.3-eap
+linter: jetbrains/qodana-cdnet:2025.2
 bootstrap: |
   git clone --depth 1 https://github.com/mrploch/mrploch-development.git /data/mrploch-development
 profile:

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: "1.0"
-linter: jetbrains/qodana-cdnet:2025.3-eap
+linter: jetbrains/qodana-cdnet:2026.1-eap
 bootstrap: |
   git clone --depth 1 https://github.com/mrploch/mrploch-development.git /data/mrploch-development
 profile:


### PR DESCRIPTION
## Describe your changes

Fixes the long-standing Qodana workflow failure (last successful state: pre-September 2025).

### Original root cause

`qodana.yaml` pinned the linter to `jetbrains/qodana-cdnet:2025.3-eap` while the workflow action was pinned to `JetBrains/qodana-action@v2025.2` (CLI 2025.2.x). The September 2025 run logged `qodana pull failed with exit code 1` plus a CLI/linter compatibility warning.

### What I learned while fixing it

1. **`jetbrains/qodana-cdnet` only publishes `-eap` tags.** There is no stable `2025.x` tag — the free Community edition ships exclusively as EAP.
2. **EAP licences expire on a rolling basis (~4-7 weeks after build date).** The PR cycled through `2025.2` (manifest not found) → `2025.2-eap` (licence expired) → `2025.3-eap` (licence expired) before landing on `2026.1-eap`, currently the only valid cdnet tag.
3. **The repo has two Qodana workflows**, and only one of them (`qodana_code_quality.yml`) was actually gating PRs. Both needed aligning.

### Final change set

- `qodana.yaml`: linter → `jetbrains/qodana-cdnet:2026.1-eap`
- `.github/workflows/code_quality.yml`: action → `@v2025.3.2`, `actions/checkout` → `@v4`
- `.github/workflows/qodana_code_quality.yml`: action → `@v2025.3.2`

The action has no `v2026.x` release yet, so running the `2026.1-eap` linter with the `v2025.3.2` action produces a non-fatal CLI/linter bracket warning. The scan runs and passes.

## Issue ticket number and link

Closes #192

Follow-up: #194 tracks the structural problem — cdnet licences will keep expiring, so either switching to the paid `qodana-dotnet` stable image, adopting `use-nightly`, automating the bumps, or removing Qodana in favour of the other analysers already in CI needs a separate decision.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests. — N/A, CI config only
- [ ] Do we need to implement analytics? — N/A
- [ ] Will this be part of a product update? — No, internal CI hygiene.

## Validation

The Qodana check on this PR passed in 4m30s after the `2026.1-eap` pin landed. All other checks green (build, SonarCloud, Codacy, CodeFactor, Sourcery, DeepSource, CodeRabbit).

## Follow-ups out of scope

- #194 — durable Qodana strategy (cdnet-dotnet switch / nightly / drop).
- `code_quality.yml` and `qodana_code_quality.yml` remain duplicative.
- `actions/checkout@v4` could be further hardened to a commit-SHA pin (sourcery-ai review comment).
