### PR TITLE
docs(site): Wire docs/ folder library pages into DocFX TOC

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -40,7 +40,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Build documentation site
-        run: dotnet docfx DocumentationSite/docfx.json
+        run: dotnet docfx DocumentationSite/docfx.json --warningsAsErrors
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/DocumentationSite/docfx.json
+++ b/DocumentationSite/docfx.json
@@ -36,6 +36,16 @@
           "toc.yml",
           "index.md"
         ]
+      },
+      {
+        "src": "..",
+        "files": [
+          "docs/**/*.md",
+          "docs/**/toc.yml"
+        ],
+        "exclude": [
+          "docs/README.md"
+        ]
       }
     ],
     "resource": [

--- a/DocumentationSite/index.md
+++ b/DocumentationSite/index.md
@@ -2,9 +2,6 @@
 
 A suite of .NET utility libraries targeting `netstandard2.0` and `net8.0+`, providing extension methods, helpers, and abstractions that simplify everyday development.
 
-> [!NOTE]
-> Full per-library documentation is available in the [docs folder](https://github.com/mrploch/ploch-common/tree/master/docs) of the repository. Integration with this site is tracked in [issue #190](https://github.com/mrploch/ploch-common/issues/190).
-
 ## Install
 
 ```bash
@@ -57,6 +54,9 @@ Abstract `ISerializer` / `IAsyncSerializer` interfaces plus implementations:
 
 ## Navigating the docs
 
+- [**Getting Started**](../docs/GETTING_STARTED.md) — installation, first steps, common use cases.
+- [**Quick Reference**](../docs/QUICK_REFERENCE.md) — cheat sheet of method signatures and common operations.
+- [**Libraries**](../docs/INDEX.md) — per-library overviews, key types, usage examples, and configuration guidance for every package in the suite.
 - [**API**](api/index.md) — auto-generated reference for every public type.
 - [**Articles**](articles/intro.md) — worked examples and usage patterns.
 - [**README** on GitHub](https://github.com/mrploch/ploch-common#readme) — comprehensive code examples and real-world scenarios.

--- a/DocumentationSite/toc.yml
+++ b/DocumentationSite/toc.yml
@@ -1,8 +1,15 @@
 - name: Home
   href: index.md
+- name: Getting Started
+  href: ../docs/GETTING_STARTED.md
+- name: Quick Reference
+  href: ../docs/QUICK_REFERENCE.md
+- name: Libraries
+  href: ../docs/
+  homepage: ../docs/INDEX.md
 - name: Articles
   href: articles/
-- name: Api Documentation
+- name: API Documentation
   href: api/
   homepage: api/index.md
 - name: GitHub

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -11,7 +11,6 @@ Complete reference documentation for all public APIs in the Ploch.Common library
   - [IsIn Extensions](#isin-extensions)
 - [Ploch.Common.Reflection](#plochcommonreflection)
   - [Type Extensions](#type-extensions)
-  - [Assembly Extensions](#assembly-extensions)
   - [Type Loader](#type-loader)
 - [Ploch.Common.IO](#plochcommonio)
   - [Path Utilities](#path-utilities)
@@ -27,7 +26,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 
 **Namespace**: `Ploch.Common`
 **Class**: `StringExtensions`
-**File**: [src/Common/StringExtensions.cs](../src/Common/StringExtensions.cs)
+**File**: [src/Common/StringExtensions.cs](https://github.com/mrploch/ploch-common/blob/master/src/Common/StringExtensions.cs)
 
 #### Null/Empty Checking Methods
 
@@ -80,7 +79,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 
 **Namespace**: `Ploch.Common.Collections`
 **Class**: `EnumerableExtensions`
-**File**: [src/Common/Collections/EnumerableExtensions.cs](../src/Common/Collections/EnumerableExtensions.cs)
+**File**: [src/Common/Collections/EnumerableExtensions.cs](https://github.com/mrploch/ploch-common/blob/master/src/Common/Collections/EnumerableExtensions.cs)
 
 #### Value Checking Methods
 
@@ -135,7 +134,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 
 **Namespace**: `Ploch.Common.ArgumentChecking`
 **Class**: `Guard`
-**File**: [src/Common/ArgumentChecking/Guard.cs](../src/Common/ArgumentChecking/Guard.cs)
+**File**: [src/Common/ArgumentChecking/Guard.cs](https://github.com/mrploch/ploch-common/blob/master/src/Common/ArgumentChecking/Guard.cs)
 
 #### Null Validation (throws ArgumentNullException)
 
@@ -173,7 +172,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 
 **Namespace**: `Ploch.Common`
 **Class**: `IsInExtensions`
-**File**: [src/Common/IsInExtensions.cs](../src/Common/IsInExtensions.cs)
+**File**: [src/Common/IsInExtensions.cs](https://github.com/mrploch/ploch-common/blob/master/src/Common/IsInExtensions.cs)
 
 #### In Methods
 
@@ -201,7 +200,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 
 **Namespace**: `Ploch.Common.Reflection`
 **Class**: `TypeExtensions`
-**File**: [src/Common/Reflection/TypeExtensions.cs](../src/Common/Reflection/TypeExtensions.cs)
+**File**: [src/Common/Reflection/TypeExtensions.cs](https://github.com/mrploch/ploch-common/blob/master/src/Common/Reflection/TypeExtensions.cs)
 
 #### Type Checking Methods
 
@@ -226,7 +225,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 
 **Namespace**: `Ploch.Common.Reflection`
 **Classes**: `TypeLoader`, `TypeLoaderConfigurator`
-**Files**: [src/Common/Reflection/TypeLoader.cs](../src/Common/Reflection/TypeLoader.cs)
+**Files**: [src/Common/Reflection/TypeLoader.cs](https://github.com/mrploch/ploch-common/blob/master/src/Common/Reflection/TypeLoader.cs)
 
 #### Configuration Methods
 
@@ -246,7 +245,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 
 **Namespace**: `Ploch.Common.IO`
 **Class**: `PathUtils`
-**File**: [src/Common/IO/PathUtils.cs](../src/Common/IO/PathUtils.cs)
+**File**: [src/Common/IO/PathUtils.cs](https://github.com/mrploch/ploch-common/blob/master/src/Common/IO/PathUtils.cs)
 
 #### Path Manipulation Methods
 
@@ -266,7 +265,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 
 **Namespace**: `Ploch.Common.Randomizers`
 **Class**: `Randomizer`
-**File**: [src/Common/Randomizers/Randomizer.cs](../src/Common/Randomizers/Randomizer.cs)
+**File**: [src/Common/Randomizers/Randomizer.cs](https://github.com/mrploch/ploch-common/blob/master/src/Common/Randomizers/Randomizer.cs)
 
 ### Randomizer Factory Methods
 
@@ -296,7 +295,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 ## Ploch.Common.DependencyInjection
 
 **Namespace**: `Ploch.Common.DependencyInjection`
-**Files**: [src/Common.DependencyInjection/](../src/Common.DependencyInjection/)
+**Files**: [src/Common.DependencyInjection/](https://github.com/mrploch/ploch-common/tree/master/src/Common.DependencyInjection/)
 
 ### Service Bundle
 
@@ -310,7 +309,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 ## Ploch.Common.Serialization
 
 **Namespace**: `Ploch.Common.Serialization`
-**Files**: [src/Common.Serialization/](../src/Common.Serialization/)
+**Files**: [src/Common.Serialization/](https://github.com/mrploch/ploch-common/tree/master/src/Common.Serialization/)
 
 ### Serializer Interface
 
@@ -330,7 +329,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 
 ## Navigation
 
-- [Home](../README.md)
+- [Home](https://github.com/mrploch/ploch-common#readme)
 - [Getting Started](GETTING_STARTED.md)
 - [Quick Reference](QUICK_REFERENCE.md)
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -225,7 +225,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 
 **Namespace**: `Ploch.Common.Reflection`
 **Classes**: `TypeLoader`, `TypeLoaderConfigurator`
-**Files**: [src/Common/Reflection/TypeLoader.cs](https://github.com/mrploch/ploch-common/blob/master/src/Common/Reflection/TypeLoader.cs)
+**Files**: [src/Common/Reflection/TypeLoader.cs](https://github.com/mrploch/ploch-common/blob/master/src/Common/Reflection/TypeLoader.cs), [src/Common/Reflection/TypeLoaderConfigurator.cs](https://github.com/mrploch/ploch-common/blob/master/src/Common/Reflection/TypeLoaderConfigurator.cs)
 
 #### Configuration Methods
 
@@ -295,7 +295,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 ## Ploch.Common.DependencyInjection
 
 **Namespace**: `Ploch.Common.DependencyInjection`
-**Files**: [src/Common.DependencyInjection/](https://github.com/mrploch/ploch-common/tree/master/src/Common.DependencyInjection/)
+**Source**: [src/Common.DependencyInjection/](https://github.com/mrploch/ploch-common/tree/master/src/Common.DependencyInjection/)
 
 ### Service Bundle
 
@@ -309,7 +309,7 @@ Complete reference documentation for all public APIs in the Ploch.Common library
 ## Ploch.Common.Serialization
 
 **Namespace**: `Ploch.Common.Serialization`
-**Files**: [src/Common.Serialization/](https://github.com/mrploch/ploch-common/tree/master/src/Common.Serialization/)
+**Source**: [src/Common.Serialization/](https://github.com/mrploch/ploch-common/tree/master/src/Common.Serialization/)
 
 ### Serializer Interface
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -463,7 +463,7 @@ public decimal CalculateDiscount(decimal price, int quantity)
 
 ## Next Steps
 
-1. **Explore the full API**: Check out the [README.md](../README.md) for comprehensive examples
+1. **Explore the full API**: Check out the [README.md](https://github.com/mrploch/ploch-common#readme) for comprehensive examples
 2. **Use the Quick Reference**: Keep [QUICK_REFERENCE.md](QUICK_REFERENCE.md) handy for common operations
 3. **Review Real-World Examples**: See practical applications in the main documentation
 4. **Experiment**: Try the extensions in your own projects
@@ -497,7 +497,7 @@ value.RequiredNotNull(nameof(value));
 
 ## Additional Resources
 
-- [Full Documentation](../README.md)
+- [Full Documentation](https://github.com/mrploch/ploch-common#readme)
 - [Quick Reference Guide](QUICK_REFERENCE.md)
 - [GitHub Repository](https://github.com/mrploch/ploch-common)
 - [Issue Tracker](https://github.com/mrploch/ploch-common/issues)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ development tasks.
 | [Getting Started Guide](GETTING_STARTED.md) | New users — installation, first steps, common use cases |
 | [Quick Reference](QUICK_REFERENCE.md)       | Experienced users — method signatures, cheat sheet      |
 | [API Reference](API_REFERENCE.md)           | Complete method reference organised by namespace        |
-| [Main README](../README.md)                 | Full feature overview with in-depth examples            |
+| [Main README](https://github.com/mrploch/ploch-common#readme)                 | Full feature overview with in-depth examples            |
 
 ## Library Documentation
 
@@ -101,4 +101,4 @@ Per-library documentation with overviews, key types, usage examples, and configu
 
 ---
 
-[Back to Main README](../README.md)
+[Back to Main README](https://github.com/mrploch/ploch-common#readme)

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -288,6 +288,6 @@ foreach (var type in types.Where(t => t.IsConcreteImplementation<IService>()))
 
 ## Getting Help
 
-- Full documentation: [README.md](../README.md)
+- Full documentation: [README.md](https://github.com/mrploch/ploch-common#readme)
 - Source code: [GitHub Repository](https://github.com/mrploch/ploch-common)
 - Report issues: [GitHub Issues](https://github.com/mrploch/ploch-common/issues)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,5 +1,7 @@
 - name: Overview
   href: INDEX.md
+- name: API Reference
+  href: API_REFERENCE.md
 - name: Core Foundation
   items:
     - name: Ploch.Common

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,86 @@
+- name: Overview
+  href: INDEX.md
+- name: Core Foundation
+  items:
+    - name: Ploch.Common
+      href: libraries/common.md
+    - name: Ploch.Common.Net9
+      href: libraries/common-net9.md
+    - name: Ploch.Common.DataAnnotations
+      href: libraries/common-data-annotations.md
+    - name: Ploch.Common.ObjectBuilder
+      href: libraries/common-object-builder.md
+    - name: Ploch.Common.Ardalis.Result
+      href: libraries/common-ardalis-result.md
+- name: Serialization
+  items:
+    - name: Ploch.Common.Serialization
+      href: libraries/common-serialization.md
+    - name: Ploch.Common.Serialization.SystemTextJson
+      href: libraries/common-serialization-system-text-json.md
+    - name: Ploch.Common.Serialization.SystemTextJson.DI
+      href: libraries/common-serialization-system-text-json-di.md
+    - name: Ploch.Common.Serialization.NewtonsoftJson
+      href: libraries/common-serialization-newtonsoft-json.md
+    - name: Ploch.Common.Serialization.NewtonsoftJson.DI
+      href: libraries/common-serialization-newtonsoft-json-di.md
+- name: Dependency Injection
+  items:
+    - name: Ploch.Common.DependencyInjection
+      href: libraries/common-dependency-injection.md
+    - name: Ploch.Common.DependencyInjection.Autofac
+      href: libraries/common-dependency-injection-autofac.md
+    - name: Ploch.Common.DependencyInjection.Hosting
+      href: libraries/common-dependency-injection-hosting.md
+    - name: Ploch.Common.Extensions.Configuration
+      href: libraries/common-extensions-configuration.md
+    - name: Ploch.Common.Dependencies
+      href: libraries/common-dependencies.md
+- name: Web, API & Applications
+  items:
+    - name: Ploch.Common.WebApi
+      href: libraries/common-webapi.md
+    - name: Ploch.Common.Web
+      href: libraries/common-web.md
+    - name: Ploch.Common.WebUI
+      href: libraries/common-webui.md
+    - name: Ploch.Common.AppServices
+      href: libraries/common-appservices.md
+    - name: Ploch.Common.AppServices.Web
+      href: libraries/common-appservices-web.md
+    - name: Ploch.Common.Apps
+      href: libraries/common-apps.md
+    - name: Ploch.Common.UseCases
+      href: libraries/common-usecases.md
+    - name: Ploch.Common.NSwag
+      href: libraries/common-nswag.md
+    - name: Ploch.Common.Maui
+      href: libraries/common-maui.md
+    - name: Ploch.Common.Windows
+      href: libraries/common-windows.md
+    - name: Ploch.Common.Windows.DependencyInjection
+      href: libraries/common-windows-di.md
+- name: Testing Support
+  items:
+    - name: Ploch.TestingSupport
+      href: libraries/testing-support.md
+    - name: Ploch.TestingSupport.XUnit3
+      href: libraries/testing-support-xunit3.md
+    - name: Ploch.TestingSupport.XUnit3.AutoMoq
+      href: libraries/testing-support-xunit3-automoq.md
+    - name: Ploch.TestingSupport.FluentAssertions
+      href: libraries/testing-support-fluent-assertions.md
+    - name: Ploch.TestingSupport.FluentAssertions.IOAbstractions
+      href: libraries/testing-support-fluent-assertions-io.md
+    - name: Ploch.TestingSupport.MockConsoleApp
+      href: libraries/testing-support-mock-console-app.md
+    - name: Ploch.TestingSupport.Dependencies.MetaPackages
+      href: libraries/testing-support-meta-packages.md
+    - name: Ploch.TestingSupport.XUnit3.Dependencies
+      href: libraries/testing-support-xunit3-dependencies.md
+    - name: Ploch.TestingSupport.XUnit2.Dependencies
+      href: libraries/testing-support-xunit2-dependencies.md
+- name: Build Configuration
+  items:
+    - name: MSBuild, Packages, Versioning
+      href: libraries/common-msbuild.md


### PR DESCRIPTION
## **User description**
## Describe your changes

Closes #190.

The repo's `docs/` folder had 40 authored markdown pages (per-library overviews, a Getting Started guide, a Quick Reference, an API overview, an index) but **none of it was wired into the DocFX site** that publishes to https://github.ploch.dev/ploch-common/. Readers of the published site could see only the auto-generated API reference. This PR threads the authored content into both the DocFX build and the site's navigation, and tightens CI so future regressions fail the build instead of landing silently.

## Changes

**New file**
- `docs/toc.yml` — groups the 36 `docs/libraries/*.md` pages into six sections (Core Foundation, Serialization, Dependency Injection, Web/API/Apps, Testing Support, Build Configuration), mirroring the groupings in `docs/INDEX.md`.

**Modified — DocFX wiring**
- `DocumentationSite/toc.yml` — adds top-level **Getting Started**, **Quick Reference**, and **Libraries** nodes pointing at `../docs/`. The Libraries node uses `homepage: ../docs/INDEX.md` so the section lands on the hub page; also fixed `Api Documentation` → `API Documentation` capitalisation.
- `DocumentationSite/docfx.json` — adds a `build.content` entry with `src: ".."` and `files: ["docs/**/*.md", "docs/**/toc.yml"]`. Uses `src` (not a `../` in the glob) because DocFX explicitly does not support `../` in file globs. Excludes `docs/README.md` (redundant with INDEX.md).
- `DocumentationSite/index.md` — drops the temporary `NOTE` promising integration with #190 (this PR delivers it) and adds direct links to Getting Started / Quick Reference / Libraries under "Navigating the docs".

**Modified — fix file links so `--warningsAsErrors` passes**
- `docs/API_REFERENCE.md` — rewrites 10 `../src/**/*.cs` file links and one `../README.md` link as absolute `github.com/mrploch/ploch-common/{blob,tree}/master/...` URLs. Files use `/blob/`, folders use `/tree/`. Also drops a stale `[Assembly Extensions](#assembly-extensions)` TOC entry that had no matching heading.
- `docs/GETTING_STARTED.md`, `docs/INDEX.md`, `docs/QUICK_REFERENCE.md` — rewrite `../README.md` references the same way.

**Modified — CI**
- `.github/workflows/publish-docs.yml` — appends `--warningsAsErrors` to the `dotnet docfx` invocation so future broken xrefs, missing TOC entries, or unresolved file links fail the build.

## Design decisions

- **`src: ".."` instead of `src: "../docs"`.** With `src: "../docs"` + `files: ["**/*.md"]`, `docs/INDEX.md` lands at `_site/INDEX.md` — case-insensitive collision on Windows with the existing `_site/index.md` from the site homepage, and semantically weird (two root-level index pages). Using `src: ".."` + `files: ["docs/**/*.md"]` preserves the `docs/` prefix in the output, so the authored content sits cleanly at `_site/docs/...`.
- **`exclude: ["docs/README.md"]`.** `docs/README.md` is a redundant "front porch" for the docs folder that duplicates INDEX.md's role. Including it would create two overlapping hub pages. The file is still useful when browsing the `docs/` folder on GitHub; it just doesn't need to be its own site page.
- **Absolute GitHub URLs for `../README.md` and `../src/**/*.cs` links.** These links previously resolved to paths outside the DocFX content tree and produced `InvalidFileLink` warnings, which `--warningsAsErrors` would turn into build failures. Converting to absolute URLs is the minimum change that (a) keeps the links working when viewing the docs on GitHub and (b) satisfies DocFX's link validator. `xref:` was not applicable — these links point at source files and a README, not API types.
- **Not converting library-page type names to `xref:`.** The issue mentions converting plain markdown links to `xref:` "where they point at API types" — but the existing library pages use backticked type names in prose and tables with no markdown links to API pages. Adding xrefs would be a new feature (wrapping type names in clickable links), not a conversion. Left out of scope; no warnings relate to it.
- **Optional per-namespace overwrite files left out of scope.** Issue checklist item 8 was flagged as optional ("Optional: add per-namespace overwrite files in `DocumentationSite/namespaces/`"). Adding more would require authored content for each namespace and doesn't block the wiring the rest of the PR delivers.

## Testing

- Local build (`dotnet docfx DocumentationSite/docfx.json`): DocFX processes 46 conceptual files (up from 5 pre-PR). Every library page listed in `docs/INDEX.md` is reachable from the top-level TOC.
- No `InvalidFileLink`, `InvalidBookmark`, or TOC-reference warnings remain from `docs/` content after this PR.
- `_site/docs/libraries/` contains all 36 rendered library HTMLs; `_site/docs/{INDEX,GETTING_STARTED,QUICK_REFERENCE,API_REFERENCE,toc}.html` all present.

## Out of scope / pre-existing issues flagged

`.github/workflows/publish-docs.yml` has been failing on `master` since before this PR (NU1010 Central Package Management errors from upstream infra, unrelated to DocFX content). This PR's `--warningsAsErrors` addition does not change that pre-existing failure mode — it catches a different class of future regression (docs content issues). Fixing the CPM errors is tracked separately and out of scope here.

Pre-existing DocFX metadata-extraction errors in `Common.Maui.Tests.TestAssembly1/2` (CS0234/CS0246) and `Common.WebApi/OpenApiConfigurator.cs` (missing `OpenApiInfo`) surface locally; same root cause — broken upstream references, not DocFX configuration. Out of scope.

## Related

- Closes #190
- Parent: #123 (docs overhaul umbrella)
- Depends on #191 (DocFX P0 quick-wins) — merged.

## Summary by Sourcery

Integrate the authored markdown documentation under docs/ into the DocFX site, improve site navigation, and tighten CI to treat documentation warnings as build failures.

New Features:
- Expose Getting Started, Quick Reference, and Libraries documentation pages in the DocFX site navigation.
- Add a dedicated docs/toc.yml to organize per-library documentation into logical sections within the site.

Bug Fixes:
- Resolve invalid relative links in conceptual docs by converting them to working GitHub URLs, eliminating DocFX file-link warnings.

Enhancements:
- Update the documentation site home page to directly link into key authored docs and reflect the wired-in library documentation.
- Normalize API documentation naming in the DocFX TOC for consistency.

CI:
- Configure the docs publish workflow to run DocFX with warnings treated as errors to prevent regressions in documentation wiring and links.


___

## **CodeAnt-AI Description**
**Publish the authored docs in the site navigation and fix broken doc links**

### What Changed
- The docs site now includes direct navigation to Getting Started, Quick Reference, and the full Libraries section, instead of exposing only the API reference.
- The library documentation pages are grouped into the docs site so readers can browse the per-library overviews from the published site.
- Several links inside the docs were updated to point to the correct GitHub pages, and a stale table-of-contents entry was removed so the docs build passes without broken links.
- The docs publish workflow now fails when documentation warnings occur, so link or table-of-contents problems do not reach the live site unnoticed.

### Impact
`✅ Easier access to library guides`
`✅ Fewer broken doc links`
`✅ Safer docs releases`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=KfUuJBxflgu8Pneq5o__zdf2WKVWj-ry1QF4DtM2o8A&org=mrploch)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
