### PR TITLE
ci(qodana): Disable automatic triggers until #194 is resolved

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -1,11 +1,16 @@
 name: Qodana
+# Automatic triggers are disabled while #194 tracks a durable fix.
+# qodana-cdnet (the Community image we are entitled to) ships EAP-only
+# tags with rolling licence expiry, so any fixed pin breaks CI on a
+# ~4-7 week cycle. Option A (qodana-dotnet stable) was confirmed
+# unavailable — the Qodana Cloud project has only a Community licence.
+# Option B (use-nightly) is deprecated and 404s. Until #194 decides
+# between option C (automated bump workflow) and option D (drop Qodana
+# in favour of SonarCloud/Codacy/DeepSource/CodeFactor/CodeRabbit/
+# Sourcery, which already run and pass on every PR), Qodana runs only
+# on manual dispatch.
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches: # Specify your branches here
-      - master # The 'main' branch
-      - 'releases/*' # The release branches
 
 jobs:
   qodana:

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -25,6 +25,11 @@ jobs:
         uses: JetBrains/qodana-action@v2025.3.2
         with:
           pr-mode: false
+          # use-nightly pulls the freshest EAP cdnet image — qodana-cdnet only
+          # ships EAP tags with rolling licence expiry, so pinning a single tag
+          # recurrently breaks CI (see #194). Overrides the linter pin in
+          # qodana.yaml for this run.
+          use-nightly: true
           args: --baseline,qodana.sarif.json,--solution,Ploch.Common.slnx
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -25,11 +25,6 @@ jobs:
         uses: JetBrains/qodana-action@v2025.3.2
         with:
           pr-mode: false
-          # use-nightly pulls the freshest EAP cdnet image — qodana-cdnet only
-          # ships EAP tags with rolling licence expiry, so pinning a single tag
-          # recurrently breaks CI (see #194). Overrides the linter pin in
-          # qodana.yaml for this run.
-          use-nightly: true
           args: --baseline,qodana.sarif.json,--solution,Ploch.Common.slnx
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: "1.0"
-linter: jetbrains/qodana-cdnet:2026.1-eap
+linter: jetbrains/qodana-dotnet:2025.3
 bootstrap: |
   git clone --depth 1 https://github.com/mrploch/mrploch-development.git /data/mrploch-development
 profile:

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: "1.0"
-linter: jetbrains/qodana-dotnet:2025.3
+linter: jetbrains/qodana-cdnet:2026.1-eap
 bootstrap: |
   git clone --depth 1 https://github.com/mrploch/mrploch-development.git /data/mrploch-development
 profile:


### PR DESCRIPTION
## Summary

Qodana on master broke again — `jetbrains/qodana-cdnet:2026.1-eap` now carries an already-expired ReSharper C++ RC component. This PR started out trying the two quick-fix options from #194 (B and A), and pivoted to **option D (disable automatic runs)** once logs confirmed those options aren't available in this environment.

## What I tried, in order

1. **Option B: `use-nightly: true`** → action logs:
   > Input 'use-nightly' has been deprecated with message: This option is for development purposes only. Do not use it in production.
   
   Followed by `##[error]Unexpected HTTP response: 404`. Dead end.

2. **Option A: switch linter to `jetbrains/qodana-dotnet:2025.3` (stable, non-expiring)** → Qodana Cloud response:
   > Your Qodana Cloud organization has Community license that doesn't support "Qodana for .NET" linter ... obtain Ultimate or Ultimate Plus license.
   
   Also dead end without a licence upgrade.

3. **Checked Docker Hub for a fresher cdnet tag** — latest published is `2026.1-eap` (built 2026-03-24), the same tag that's now expired. No newer EAP yet.

4. **Option D: disable automatic runs** → this PR.

## Changes

### `.github/workflows/qodana_code_quality.yml`
Triggers reduced to `workflow_dispatch` only (same pattern as the already-dormant `code_quality.yml`). The workflow is kept, not deleted — maintaining `workflow_dispatch` means anyone can still run a Qodana scan ad-hoc if needed, and the config is ready to re-arm once #194 lands a durable decision.

Added a block comment at the top of the file explaining why auto-runs are off.

### `qodana.yaml`
Reverted the transient switch to `qodana-dotnet:2025.3` (needed Ultimate) back to `jetbrains/qodana-cdnet:2026.1-eap` — the newest published cdnet tag, which will still resolve for local CLI runs that don't use Qodana Cloud.

## Why this is the right call for a master-unblock PR

- The two quick-fix options from #194 are both empirically unavailable (logs confirm).
- Option C (automated bump workflow) and the formal option D (drop Qodana entirely) are **structural choices** that deserve their own discussion on #194, not a drive-by decision inside a CI-unblock PR.
- The repo already runs six other quality gates that **are passing on every PR**: SonarCloud, Codacy, CodeFactor, Sourcery, DeepSource, CodeRabbit. The marginal cost of pausing Qodana is low.
- This PR is reversible: one line to re-enable push/pull_request triggers when #194 has a plan.

## Testing

Can only validate in CI — after merge, future master pushes will skip Qodana and future PRs won't see a Qodana check at all.

## Related

- Refs #194 — this PR implements the minimum-viable step (disable auto-runs). #194 stays open to track the durable structural choice between automated bumps, paid licence, or removal.
- Supersedes the EAP-bump cycle started by #193.