### PR TITLE
fix(ci): Match per-TFM coverage files in Sonar/Codacy globs

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -89,7 +89,7 @@ jobs:
           /d:sonar.host.url="https://sonarcloud.io"
           /d:sonar.projectBaseDir="${{ github.workspace }}"
           /d:sonar.scm.provider=git
-          /d:sonar.cs.opencover.reportsPaths=**/CoverageResults/coverage.opencover.xml
+          /d:sonar.cs.opencover.reportsPaths=**/CoverageResults/coverage*.opencover.xml
           /d:sonar.coverage.exclusions="**/*.ps1,**/JetbrainsAnnotations.cs,**/*.Tests/**,**/*.Tests.csproj"
         continue-on-error: true
 
@@ -113,7 +113,7 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: '**/CoverageResults/coverage.opencover.xml'
+          coverage-reports: '**/CoverageResults/coverage*.opencover.xml'
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v4

--- a/change-log/2026-05-14-217-sonarcloud-coverage-multitarget-glob.md
+++ b/change-log/2026-05-14-217-sonarcloud-coverage-multitarget-glob.md
@@ -6,7 +6,7 @@
 
 ### Why
 
-After #207 / #209 multi-targeted `Ploch.Common.Tests` to `net10.0;net8.0` (so CI exercises both the `net8.0` and `netstandard2.0` builds of `Ploch.Common`), Coverlet started emitting per-TFM filenames for that project:
+After #207 / #209, `Ploch.Common.Tests` was multi-targeted to `net10.0;net8.0` (so CI exercises both the `net8.0` and `netstandard2.0` builds of `Ploch.Common`), and Coverlet started emitting per-TFM filenames for that project:
 
 - `tests/Common.Tests/CoverageResults/coverage.net10.0.opencover.xml`
 - `tests/Common.Tests/CoverageResults/coverage.net8.0.opencover.xml`

--- a/change-log/2026-05-14-217-sonarcloud-coverage-multitarget-glob.md
+++ b/change-log/2026-05-14-217-sonarcloud-coverage-multitarget-glob.md
@@ -1,0 +1,21 @@
+## Fix SonarCloud and Codacy coverage on multi-targeted test projects
+
+### CI
+
+- **Updated `.github/workflows/build-dotnet.yml`** so the SonarCloud and Codacy coverage globs pick up per-TFM OpenCover reports emitted by Coverlet when a test project is multi-targeted. Both globs changed from `**/CoverageResults/coverage.opencover.xml` to `**/CoverageResults/coverage*.opencover.xml`.
+
+### Why
+
+After #207 / #209 multi-targeted `Ploch.Common.Tests` to `net10.0;net8.0` (so CI exercises both the `net8.0` and `netstandard2.0` builds of `Ploch.Common`), Coverlet started emitting per-TFM filenames for that project:
+
+- `tests/Common.Tests/CoverageResults/coverage.net10.0.opencover.xml`
+- `tests/Common.Tests/CoverageResults/coverage.net8.0.opencover.xml`
+
+The previous globs matched only the literal name `coverage.opencover.xml`, so neither file was ingested. SonarCloud therefore saw coverage from the small satellite test projects only and reported `6.77%` instead of the local `~86%`, which tripped the Quality Gate. Codacy was silently affected the same way.
+
+Sonar and Codacy both ingest multiple OpenCover reports and merge them by source file path (set-union of covered lines), so reading both per-TFM reports correctly combines coverage of the `#if NETSTANDARD2_0` and `#if NET7_0_OR_GREATER` branches — which is precisely what #209 set out to achieve.
+
+### Refs
+
+- Closes part of #217 (SonarCloud badges reporting wrong coverage). The Qodana badge problem mentioned in the same issue is tracked separately and relates to #194.
+- Builds on #207 / #209 (multi-targeted `Ploch.Common.Tests`).


### PR DESCRIPTION
## **User description**
## Describe your changes

Widens the SonarCloud and Codacy coverage globs in `.github/workflows/build-dotnet.yml` from `**/CoverageResults/coverage.opencover.xml` to `**/CoverageResults/coverage*.opencover.xml` so they ingest per-TFM OpenCover reports emitted by Coverlet on multi-targeted test projects.

### Root cause

After #207 / #209 multi-targeted `Ploch.Common.Tests` to `net10.0;net8.0` (so CI exercises both the `net8.0` and `netstandard2.0` builds of `Ploch.Common`), Coverlet started emitting per-TFM filenames for that project. Evidence from the master CI run after PR #209 merged (run `25768221673`):

```
tests/Common.Tests/CoverageResults/coverage.net10.0.opencover.xml
tests/Common.Tests/CoverageResults/coverage.net8.0.opencover.xml
```

All other (single-target) test projects still emit `coverage.opencover.xml`. The previous glob was a literal-filename match and therefore silently dropped `Common.Tests` — the largest test project (804 + 762 tests covering the bulk of `Ploch.Common`). SonarCloud reported `6.77%` coverage instead of `~86%` and the Quality Gate badge failed. Codacy was silently affected the same way.

### The fix

Widen the glob. The `*` between `coverage` and `.opencover.xml` matches:

- `coverage.opencover.xml` (legacy single-TFM, unchanged)
- `coverage.net8.0.opencover.xml` ✓
- `coverage.net10.0.opencover.xml` ✓
- Any future `coverage.<TFM>.opencover.xml` from later multi-target work

### Why merging two reports is correct

SonarCloud and Codacy both ingest multiple OpenCover reports and merge them by source file path (set-union of covered lines). PR #209's whole point is that conditional compilation (`#if NETSTANDARD2_0` vs `#if NET7_0_OR_GREATER`) compiles different lines of the same source file into the two binaries — the net10.0 leg covers the `NET7_0_OR_GREATER` branch, the net8.0 leg covers the `NETSTANDARD2_0` branch. The union of coverage across both reports is exactly the combined picture #209 set out to produce.

### Design decisions

- Chose the glob widening over a `reportgenerator`-based merge step. Glob widening is a 2-character change with no new tool dependency; Sonar/Codacy multi-report ingestion is the documented, supported handling for multi-TFM .NET. A merge step would solve a presentation problem (one file vs many) that we don't currently have.
- The Qodana badge problem mentioned in #217 is out of scope here — it relates to #194 and is a separate failure mode.

### Verification

- CI on this PR should observe SonarCloud Quality Gate returning to green with coverage `~86%` rather than `6.77%`.
- Codacy coverage report should reflect the same recovery.
- The `coverage.exclusions` filter (`**/*.Tests/**`, `**/*.Tests.csproj`, etc.) is unchanged, so test code remains excluded from coverage measurement.

## Issue ticket number and link

Closes part of #217 — specifically the SonarCloud coverage / Quality Gate badge issue. The Qodana badge issue noted in #217 is not addressed here.

Builds on #207 / #209.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. — N/A (CI config fix, validated by the next CI run)
- [ ] Do we need to implement analytics? — N/A
- [ ] Will this be part of a product update? If yes, please write one phrase about this update. — Internal CI fix; no consumer-visible change.

## Summary by Sourcery

Update CI coverage configuration so SonarCloud and Codacy ingest multi-targeted OpenCover reports from .NET test projects.

CI:
- Broaden SonarCloud OpenCover report glob to include per-TFM coverage files emitted by multi-targeted test projects.
- Broaden Codacy coverage report glob to include per-TFM coverage files emitted by multi-targeted test projects.

Documentation:
- Add changelog entry documenting the CI coverage glob fix and its relation to multi-targeted tests and issue #217.


___

## **CodeAnt-AI Description**
**Fix coverage reporting for multi-targeted test projects**

### What Changed
- SonarCloud and Codacy now pick up coverage reports from multi-targeted test runs, instead of skipping them when the report name includes a target framework.
- The CI workflow still accepts the original single-report filename, while also matching the new per-target report files created by multi-targeted tests.
- This restores full coverage reporting for the large `Common.Tests` suite, which had been missing from badge and quality gate results.

### Impact
`✅ Accurate coverage badges`
`✅ Fewer false quality gate failures`
`✅ Coverage from multi-targeted tests is included`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI coverage reporting accuracy for multi-framework .NET projects by updating glob patterns to capture all generated coverage reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mrploch/ploch-common/pull/218)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->