### PR TITLE
fix(ci): Exclude build scripts and TestAssemblies from SonarCloud coverage

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -90,7 +90,7 @@ jobs:
           /d:sonar.projectBaseDir="${{ github.workspace }}"
           /d:sonar.scm.provider=git
           /d:sonar.cs.opencover.reportsPaths=**/CoverageResults/coverage*.opencover.xml
-          /d:sonar.coverage.exclusions="**/*.ps1,**/JetbrainsAnnotations.cs,**/*.Tests/**,**/*.Tests.csproj"
+          /d:sonar.coverage.exclusions="**/*.ps1,**/JetbrainsAnnotations.cs,**/*.Tests/**,**/*.Tests.csproj,scripts/**,**/TestAssemblies/**"
         continue-on-error: true
 
       # Build and Test (always runs regardless of SonarCloud status)

--- a/change-log/2026-05-14-217-sonar-exclude-test-infrastructure.md
+++ b/change-log/2026-05-14-217-sonar-exclude-test-infrastructure.md
@@ -1,0 +1,41 @@
+## Exclude build scripts and test-fixture assemblies from SonarCloud coverage
+
+### CI
+
+- **Updated `.github/workflows/build-dotnet.yml`** to add `scripts/**` and `**/TestAssemblies/**` to `sonar.coverage.exclusions`. The full pattern is now:
+
+```
+**/*.ps1,**/JetbrainsAnnotations.cs,**/*.Tests/**,**/*.Tests.csproj,scripts/**,**/TestAssemblies/**
+```
+
+### Why
+
+After PRs #218 and #219, SonarCloud coverage climbed from `6.77%` to `72.3%` composite (`68.6%` line). Local Rider DotCover and `dotnet-reportgenerator-globaltool` both reported `~86%` line coverage — a remaining `~17`-percentage-point gap.
+
+Querying the SonarCloud API for per-folder coverage revealed the gap was driven by **two folders being measured but not actually meaningful production code**:
+
+| Folder | Lines counted | Uncovered | Coverage |
+| --- | --- | --- | --- |
+| `scripts/` | 427 | 427 | 0.0% |
+| `tests/TestAssemblies/` | 112 | 35 | 68.8% |
+| `src/` | 1331 | 125 | 90.6% |
+
+- **`scripts/`** contains build/CI helpers — eight PowerShell files (caught by the existing `**/*.ps1` pattern, correctly excluded) and **`generate-api-reference.py`**, a ~24 KB Python script that Sonar's Python analyzer instruments. With ~400 effective lines reported as uncoverable, this single file accounted for `427 / 587 = 73 %` of the total uncovered-line count.
+- **`tests/TestAssemblies/`** holds Reflection test fixtures (`Common.Tests.TestAssembly1`, `Common.Tests.TestAssembly2`, `Common.Tests.TestTypes`) used as instrumentation targets by `Common.Tests`. Despite living under `tests/`, the path does not match the existing `**/*.Tests/**` glob, so it leaked into the coverage measurement.
+
+Neither set of files should drag the coverage badge down: build tooling is not consumer-visible, and test fixtures are intentionally not exhaustively tested.
+
+### Expected impact
+
+With these exclusions in place, the next master analysis should report:
+
+- Covered lines: `1283` (unchanged)
+- Total lines: `1870 - 427 - 112 = 1331`
+- Line coverage: **`1283 / 1331 ≈ 90.6 %`**
+
+That brings SonarCloud in line with the local `dotnet-reportgenerator` numbers (with-filter `88.7 %`, no-filter `86.2 %`) and the Rider DotCover figure (`~86 %`).
+
+### Refs
+
+- Closes the final part of #217 (SonarCloud reporting artificially low coverage). The Qodana badge issue noted in #217 is still pending — relates to #194 and will be addressed separately.
+- Builds on #218 (per-TFM glob fix) and #219 (central Coverlet injection + duplicate-reference cleanup).

--- a/change-log/2026-05-14-217-sonar-exclude-test-infrastructure.md
+++ b/change-log/2026-05-14-217-sonar-exclude-test-infrastructure.md
@@ -29,9 +29,10 @@ Neither set of files should drag the coverage badge down: build tooling is not c
 
 With these exclusions in place, the next master analysis should report:
 
-- Covered lines: `1283` (unchanged)
+- Covered lines: `1283 - 77 = 1206`  
+  (the 77 covered lines come from `tests/TestAssemblies/`, which previously contributed `112` lines with `35` uncovered; `scripts/` contributed `0` covered lines so it has no effect here)
 - Total lines: `1870 - 427 - 112 = 1331`
-- Line coverage: **`1283 / 1331 ≈ 90.6 %`**
+- Line coverage: **`1206 / 1331 ≈ 90.6 %`**
 
 That brings SonarCloud in line with the local `dotnet-reportgenerator` numbers (with-filter `88.7 %`, no-filter `86.2 %`) and the Rider DotCover figure (`~86 %`).
 


### PR DESCRIPTION
## Describe your changes

Widens `sonar.coverage.exclusions` in `.github/workflows/build-dotnet.yml` to add `scripts/**` and `**/TestAssemblies/**`. Both folders were being counted as production code requiring coverage, even though neither is consumer-visible.

### Root cause analysis

After #218 and #219, SonarCloud climbed from `6.77%` → `72.3%` composite coverage on master. Local Rider DotCover and `dotnet-reportgenerator-globaltool` both report `~86%`. Querying SonarCloud's component-tree API (`/api/measures/component_tree?strategy=children`) revealed the remaining gap:

| Folder | `lines_to_cover` | `uncovered_lines` | `line_coverage` |
| --- | --- | --- | --- |
| `scripts/` | 427 | 427 | **0.0%** |
| `tests/TestAssemblies/` | 112 | 35 | 68.8% |
| `src/` | 1331 | 125 | 90.6% |

- `scripts/generate-api-reference.py` is a ~24 KB Python helper that SonarCloud's Python analyzer instruments. It accounts for `427 / 587 = 73 %` of the project's total uncovered-line count.
- `tests/TestAssemblies/` holds Reflection test fixtures (`Common.Tests.TestAssembly1`, `Common.Tests.TestAssembly2`, `Common.Tests.TestTypes`) consumed by `Common.Tests` via reflection. The path does not match the existing `**/*.Tests/**` glob.

Neither set is production code, and excluding them is consistent with how Rider DotCover and `reportgenerator` handle the same paths.

### Expected impact

After this change, Sonar should report approximately:

- Covered lines: `1283 - 77 = 1206`  (the 77 covered lines come from `tests/TestAssemblies/`, which previously contributed 112 lines with 35 uncovered; `scripts/` contributed 0 covered lines so it has no effect here)
- Total lines: `1870 − 427 − 112 = 1331`
- **Line coverage: `1206 / 1331 ≈ 90.6 %`**

Bringing Sonar in line with local `dotnet-reportgenerator` numbers (with-filter `88.7 %`, no-filter `86.2 %`) and Rider DotCover (`~86 %`).

### Design decisions

- **Glob over path-list.** `scripts/**` covers any future build/CI helpers added under that folder (Python, shell, future Node scripts, etc.), not just `.py`. More resilient than `**/*.py`.
- **Did not add `**/*.py` globally.** `scripts/**` is precisely the directory of build tooling. Adding a global Python exclusion could accidentally hide a future legitimate Python source file under `src/`.
- **Did not exclude `src/TestingSupport.*`.** Those projects ship as public NuGet packages (`Ploch.TestingSupport`, `Ploch.TestingSupport.XUnit3`, etc.). Their coverage matters for consumers — keep them measured.
- **Did not touch `sonar.exclusions`.** Excluded files are still analysed for quality (issues, duplications) — only coverage measurement is skipped. That is the intended behaviour: `scripts/generate-api-reference.py` should still be scanned for Python issues.

### Verification

- Locally enumerated which folders Sonar counts and which it excludes via:
  ```
  curl -s "https://sonarcloud.io/api/measures/component_tree?component=mrploch_ploch-common&metricKeys=coverage,line_coverage,uncovered_lines,lines_to_cover&strategy=children&ps=100"
  ```
- Confirmed `**/*.ps1` catches the eight `.ps1` helpers (they appear with `ncloc` but no `uncovered_lines`).
- Confirmed `scripts/generate-api-reference.py` is the dominant source of uncovered Python lines.
- The next master CI run after merge will produce the actual updated number on the SonarCloud dashboard — that is the empirical confirmation.

## Issue ticket number and link

Closes the remaining part of #217 (SonarCloud reporting artificially low coverage). The Qodana badge issue noted in #217 is still pending — relates to #194 and is out of scope for this PR.

Follows #218 (per-TFM coverage glob) and #219 (central Coverlet injection + duplicate-reference cleanup).

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. — N/A (CI config; validated end-to-end by the next master CI run + SonarCloud dashboard)
- [ ] Do we need to implement analytics? — N/A
- [ ] Will this be part of a product update? — Internal CI fix; no consumer-visible change.