### PR TITLE
chore(code-quality): Disable IDE0058 (Expression value is never used)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -174,6 +174,18 @@ dotnet_code_quality.points_to_analysis_kind = Complete
 
 # Properties: 'dotnet_diagnostic'
 
+## IDE rules
+# IDE0058 ("Expression value is never used") is suppressed: ArgumentChecking
+# extension methods (Guard.NotNull, PathGuard.RequireValidPath, etc.) return the
+# argument for fluent-chaining but their primary purpose is the validation
+# side-effect, so callers idiomatically discard the result. The rule also
+# fires extensively on fluent helpers (StringBuilder.Append, ICollection.Add
+# returning bool, LINQ chains, TestingSupport setup helpers). With no built-in
+# C# attribute to mark a method "return value optional", per-call-site
+# `_ = method()` discards across 130+ sites are impractical, and the rule
+# catches nothing that other analysers (S2201, CA1806) do not already cover.
+dotnet_diagnostic.IDE0058.severity = none
+
 ## XML Documentation headers
 dotnet_diagnostic.classdocumentationheader.severity = warning # XML documentation header for class - use in apps and tests
 dotnet_diagnostic.interfacedocumentationheader.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -174,18 +174,6 @@ dotnet_code_quality.points_to_analysis_kind = Complete
 
 # Properties: 'dotnet_diagnostic'
 
-## IDE rules
-# IDE0058 ("Expression value is never used") is suppressed: ArgumentChecking
-# extension methods (Guard.NotNull, PathGuard.RequireValidPath, etc.) return the
-# argument for fluent-chaining but their primary purpose is the validation
-# side-effect, so callers idiomatically discard the result. The rule also
-# fires extensively on fluent helpers (StringBuilder.Append, ICollection.Add
-# returning bool, LINQ chains, TestingSupport setup helpers). With no built-in
-# C# attribute to mark a method "return value optional", per-call-site
-# `_ = method()` discards across 130+ sites are impractical, and the rule
-# catches nothing that other analysers (S2201, CA1806) do not already cover.
-dotnet_diagnostic.IDE0058.severity = none
-
 ## XML Documentation headers
 dotnet_diagnostic.classdocumentationheader.severity = warning # XML documentation header for class - use in apps and tests
 dotnet_diagnostic.interfacedocumentationheader.severity = warning
@@ -295,6 +283,16 @@ dotnet_diagnostic.faa0002.severity = warning
 dotnet_diagnostic.ide0001.severity = suggestion # Simplify name
 dotnet_diagnostic.ide0002.severity = error # Simplify name
 dotnet_diagnostic.ide0018.severity = warning # Inline variable declaration
+# IDE0058 ("Expression value is never used") is intentionally disabled: ArgumentChecking
+# extension methods (Guard.NotNull, PathGuard.RequireValidPath, etc.) return the argument
+# for fluent-chaining but their primary purpose is the validation side-effect, so callers
+# idiomatically discard the result. The rule also fires on many other fluent / side-effect
+# helpers in the codebase (StringBuilder.Append chains, ISet<T>.Add returning bool, LINQ
+# helpers, TestingSupport setup methods). C# has no attribute that lets a method declare
+# "discarding my return value is allowed", so per-call-site `_ = method()` discards across
+# 130+ sites would be impractical. See change-log entry 2026-05-15-disable-ide0058-* for
+# the full rationale and the trade-off (lazy-LINQ misuse is no longer caught by IDE0058).
+dotnet_diagnostic.ide0058.severity = none
 
 ## Properties: 'dotnet_diagnostic.nu'
 dotnet_diagnostic.nu1507.severity = none # Use nameof operator

--- a/change-log/2026-05-15-disable-ide0058-expression-value-never-used.md
+++ b/change-log/2026-05-15-disable-ide0058-expression-value-never-used.md
@@ -1,0 +1,37 @@
+## Disable IDE0058 ("Expression value is never used") globally
+
+### Code quality
+
+- **Updated `.editorconfig`** to set `dotnet_diagnostic.IDE0058.severity = none`. The rule was producing 137+ false positives on SonarCloud and SonarLint, primarily on intentional discards of `ArgumentChecking` extension-method results.
+
+### Why
+
+`ArgumentChecking` extension methods such as `Guard.NotNull`, `PathGuard.RequireValidPath`, `Guard.NotNullOrEmpty`, and `Guard.NotOutOfRange` return their input argument so callers can fluent-chain them when convenient, but their **primary purpose is the validation side-effect** — throwing on bad input. Callers idiomatically write `arg.NotNull(nameof(arg));` and discard the result. Roslyn's `IDE0058` (surfaced by SonarCloud as `external_roslyn:IDE0058`) flags every such call as "Expression value is never used", producing many false positives.
+
+The rule also fires on numerous other intentional fluent-API discards in the codebase:
+
+- `StringBuilder.Append(...).Append(...)` chains where the final result isn't reassigned
+- `ICollection<T>.Add(...)` (returns `bool` indicating "was added")
+- LINQ-for-side-effect helpers (`ForEach` over results of `Where`)
+- Reflection helpers and `TestingSupport` setup methods that mutate state and return `this`
+
+### Why per-method suppression isn't possible
+
+`IDE0058` fires **on the caller**, not on the method being called. C# has no built-in attribute that lets a method declare "discarding my return value is allowed" (`[Pure]` does the opposite — it tells callers they *must* use the result). Suppression would therefore require either:
+
+- `_ = method();` discards at every call site (130+ sites; impractical to apply retroactively, and noisy on every new call going forward), or
+- Per-file `[SuppressMessage]` / `#pragma warning disable IDE0058` (same problem at scale).
+
+### Why this is safe
+
+`IDE0058` catches nothing that other analysers don't already catch on a tighter scope:
+
+- **`csharpsquid:S2201`** ("Return values from functions without side effects should not be ignored") — Sonar's equivalent rule, but it correctly recognises that side-effecting methods like `Guard.NotNull` are fine to call without using the return value.
+- **`CA1806`** ("Do not ignore method results") — similar Roslyn rule, fires only on pure / no-side-effect methods.
+
+The codebase already declared the preference at `csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion`, so the `_ = method()` discard remains the documented refactoring suggestion in the IDE if anyone wants it. We just don't enforce it.
+
+### Verification
+
+- Local `dotnet build ./Ploch.Common.slnx -c Release` after the change: zero `IDE0058` occurrences, zero errors.
+- The next master analysis after merge should show `external_roslyn:IDE0058` drop out of the Sonar issue list entirely.

--- a/change-log/2026-05-15-disable-ide0058-expression-value-never-used.md
+++ b/change-log/2026-05-15-disable-ide0058-expression-value-never-used.md
@@ -22,14 +22,18 @@ The rule also fires on numerous other intentional fluent-API discards in the cod
 - `_ = method();` discards at every call site (130+ sites; impractical to apply retroactively, and noisy on every new call going forward), or
 - Per-file `[SuppressMessage]` / `#pragma warning disable IDE0058` (same problem at scale).
 
-### Why this is safe
+### Trade-off
 
-`IDE0058` catches nothing that other analysers don't already catch on a tighter scope:
+Other analysers cover most of the cases `IDE0058` does, but on a **narrower scope**:
 
-- **`csharpsquid:S2201`** ("Return values from functions without side effects should not be ignored") — Sonar's equivalent rule, but it correctly recognises that side-effecting methods like `Guard.NotNull` are fine to call without using the return value.
-- **`CA1806`** ("Do not ignore method results") — similar Roslyn rule, fires only on pure / no-side-effect methods.
+- **`csharpsquid:S2201`** ("Return values from functions without side effects should not be ignored") — Sonar's nearest equivalent. Correctly recognises that side-effecting methods like `Guard.NotNull` are fine to call without using the return value, which is why it does not fire on the false-positive cases.
+- **`CA1806`** ("Do not ignore method results") — fires only on a specific list of known pure / no-side-effect APIs (string methods, `Immutable*` types, etc.).
 
-The codebase already declared the preference at `csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion`, so the `_ = method()` discard remains the documented refactoring suggestion in the IDE if anyone wants it. We just don't enforce it.
+The genuine residual risk is **lazy-LINQ chains**: something like `myList.Where(x => x.Active)` with no `.ToList()` / no assignment is a real bug that `IDE0058` would catch but `S2201` and `CA1806` will not. We accept this trade-off because:
+
+1. The rule produced 137+ false positives on master at the time of this change, almost all on intentional fluent / side-effect discards. Signal-to-noise is too low to be useful.
+2. The wider Sonar issue list — surfaced after the coverage-instrumentation fixes (#218 / #219 / #220) — is what motivated this; the rule was actively obscuring the genuine code smells in the project.
+3. The existing IDE preference `csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion` (line 163 of `.editorconfig`) is **left in place**, so `_ = method()` remains the documented refactoring suggestion when anyone wants it. The hint just no longer fails / clutters Sonar.
 
 ### Verification
 


### PR DESCRIPTION
## **User description**
## Describe your changes

Adds `dotnet_diagnostic.IDE0058.severity = none` to the root `.editorconfig` so the Roslyn IDE0058 rule no longer fires anywhere in the repo.

### Why

While triaging the new-code-smells on SonarCloud after #220 merged, we noticed that **`external_roslyn:IDE0058`** ("Expression value is never used") was firing 137+ times. It does not catch a real bug — almost every occurrence is on an intentional discard of a fluent-API or side-effect-only method:

- **`ArgumentChecking`** extension methods (`Guard.NotNull`, `PathGuard.RequireValidPath`, `Guard.NotNullOrEmpty`, `Guard.NotOutOfRange`, etc.) return their input argument so callers can fluent-chain when convenient, but their primary purpose is the validation side-effect.
- `StringBuilder.Append(...).Append(...)` chains where the final result is not reassigned.
- `ICollection<T>.Add(...)` (returns `bool` indicating whether the item was added).
- LINQ-for-side-effect helpers, `Common.Reflection` helpers, `TestingSupport` setup methods.

### Why per-method marking is not possible

`IDE0058` fires **on the caller**, not on the method definition. C# has no built-in attribute (no `[Pure]`, no `[ReturnValueOptional]`) that lets a method declare "discarding my return value is allowed" — `[Pure]` does the opposite, demanding callers *use* the result. The two alternatives at the call site:

- `_ = method();` discard pattern at every site — 130+ sites; impractical retroactively and noisy on every future call.
- Per-file `[SuppressMessage]` or `#pragma warning disable` — same problem at scale.

### Why this is safe

`IDE0058` catches nothing that other analysers do not already cover on a tighter scope:

- **`csharpsquid:S2201`** ("Return values from functions without side effects should not be ignored") — Sonar's equivalent. It correctly recognises that side-effecting validators like `Guard.NotNull` are fine to call without consuming the result, so it does not fire on the false-positive cases that IDE0058 does.
- **`CA1806`** ("Do not ignore method results") — fires only on pure / no-side-effect methods.

The existing IDE preference at line 163 of `.editorconfig` (`csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion`) is **left in place**, so `_ = method()` remains the documented refactoring suggestion when anyone wants it. We just stop *enforcing* it.

### Verification

- Local `dotnet build ./Ploch.Common.slnx -c Release` after the change: zero `IDE0058` occurrences, zero errors.
- The next master analysis after merge should show `external_roslyn:IDE0058` drop out of the Sonar issue list (expected reduction of ~137 from the `new_code_smells` total of 570).

## Issue ticket number and link

Refs #217 — broader SonarCloud cleanup. The original ticket's coverage-badge concern is closed by #218 / #219 / #220; this PR addresses one of the code-smell categories that surfaced when looking at the dashboard afterwards.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. — N/A (analyser configuration; validated by local build + the next CI analysis)
- [ ] Do we need to implement analytics? — N/A
- [ ] Will this be part of a product update? — Internal code-quality config; no consumer-visible change.

## Summary by Sourcery

Disable the Roslyn IDE0058 analyzer across the repository and document the rationale and impact in the changelog.

Enhancements:
- Update the root .editorconfig to set dotnet_diagnostic.IDE0058.severity to none, preventing expression-value-unused warnings for intentional discards.
- Add a changelog entry explaining the decision to disable IDE0058, including context, rationale, and verification steps.


___

## **CodeAnt-AI Description**
**Stop flagging valid discarded return values as warnings**

### What Changed
- Turned off IDE0058 across the repo so intentional validation calls and fluent helper chains no longer show "Expression value is never used" warnings
- Kept the existing discard suggestion in place for developers who still want to use `_ = method();` in the IDE
- Added a note explaining why this rule was disabled and what it affects

### Impact
`✅ Fewer false-positive code quality warnings`
`✅ Cleaner analysis results in SonarCloud and SonarLint`
`✅ Less noise when calling validation and fluent helper methods`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Adds `dotnet_diagnostic.IDE0058.severity = none` to the root `.editorconfig` so the Roslyn IDE0058 rule no longer fires anywhere in the repo. While triaging the new-code-smells on SonarCloud after #220 merged, we noticed that **`external_roslyn:IDE0058`** ("Expression value is never used") was firing 137+ times. It does not catch a real bug — almost every occurrence is on an intentional discard of a fluent-API or side-effect-only method.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds dotnet_diagnostic.IDE0058.severity = none to .editorconfig, suppressing warnings for unused expression values on validation and fluent API calls in .editorconfig</li>

<li>Includes explanatory comments in .editorconfig detailing why the rule is disabled and its safety, referencing coverage by other analyzers like S2201 and CA1806 in .editorconfig</li>

<li>Preserves the existing csharp_style_unused_value_expression_statement_preference setting, maintaining discard suggestions for optional use in .editorconfig</li>

</ul>
</details>

</div>