### PR TITLE
ci(workflows): Pass NBGV version to SonarScanner so 'Previous version' gate works

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -71,6 +71,17 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ./Ploch.Common.slnx
 
+      # Capture the NBGV-computed package version so SonarScanner can pass it
+      # as sonar.projectVersion. Without this, the "Previous version" new-code
+      # definition has no version history to diff against and treats the
+      # entire baseline as new code on every analysis. See issue #222.
+      - name: Get NBGV version for SonarCloud
+        id: nbgv-version
+        run: |
+          NUGET_VERSION=$(dotnet nbgv get-version --variable NuGetPackageVersion)
+          echo "nuget_version=$NUGET_VERSION" >> $GITHUB_OUTPUT
+          echo "SonarCloud project version: $NUGET_VERSION"
+
       # SonarCloud setup (non-blocking)
       - name: Install SonarCloud Scanner
         run: dotnet tool install --global dotnet-sonarscanner
@@ -85,6 +96,7 @@ jobs:
           dotnet sonarscanner begin
           /k:"${{ env.SONAR_PROJECT_KEY }}"
           /o:"${{ env.SONAR_ORGANIZATION }}"
+          /v:"${{ steps.nbgv-version.outputs.nuget_version }}"
           /d:sonar.login="$SONAR_TOKEN"
           /d:sonar.host.url="https://sonarcloud.io"
           /d:sonar.projectBaseDir="${{ github.workspace }}"

--- a/change-log/2026-05-15-222-sonarscanner-pass-nbgv-version.md
+++ b/change-log/2026-05-15-222-sonarscanner-pass-nbgv-version.md
@@ -1,0 +1,15 @@
+## CI: Pass NBGV version to SonarScanner so SonarCloud's "Previous version" new-code window works
+
+### CI
+
+- **`.github/workflows/build-dotnet.yml`** now captures NBGV's `NuGetPackageVersion` into a step output and forwards it to `dotnet sonarscanner begin` via the `/v:` parameter. Previously `sonar.projectVersion` was never supplied, which left SonarCloud with no version history to diff against. With the New Code definition set to **"Previous version"**, that caused the entire baseline (including 432 legacy code smells dating back to 2020 and 10 legacy security hotspots) to register as "new code" on every analysis, permanently failing the quality gate.
+- With this change, each master commit produces a unique `NuGetPackageVersion` (e.g. `3.1.43-prerelease`) via NBGV's commit-height counter, and each stable release jumps to its tagged version (e.g. `3.2.0`). SonarCloud's "Previous version" comparison now diffs against the prior analysis, so the new-code window reflects what each PR or commit actually touched rather than the entire history.
+- The release workflow (`release.yml`) does not invoke SonarScanner, so no change is required there.
+
+### Follow-up
+
+After this change ships, the existing 432 legacy smells and 10 hotspots will still appear in the new-code window on the *first* post-fix master analysis (because SonarCloud has no recorded prior version). A one-time admin step in SonarCloud will rebase the new-code window: switch **New Code → Specific analysis** to the first post-fix build, then switch back to **Previous version**. The 10 security hotspots will still need a manual triage in the Security Hotspots tab.
+
+### Refs
+
+- #222 (ci: pass NBGV version to SonarScanner)


### PR DESCRIPTION
## **User description**
## Describe your changes

Captures NBGV's `NuGetPackageVersion` into a step output and forwards it to `dotnet sonarscanner begin` via the `/v:` parameter in `.github/workflows/build-dotnet.yml`.

Previously the begin command never passed `/v:`, so `sonar.projectVersion` was never populated. With SonarCloud's New Code definition set to **"Previous version"**, the missing version history caused the entire baseline to register as "new code" on every analysis — 432 legacy code smells (some from commits in 2020) and 10 legacy security hotspots — permanently failing the quality gate regardless of what the latest PR actually touched.

After this change:

- **Master commits** get a unique `NuGetPackageVersion` per commit (e.g. `3.1.43-prerelease`) via NBGV's commit-height counter → "Previous version" diff = last master commit → new code = what each commit touched.
- **Stable releases via `release.yml`** jump cleanly to e.g. `3.2.0` → new-code window rebases to the prior release tag.
- **PR builds** are already overridden to `<base>-pr.<number>.<branch>` earlier in the workflow; SonarCloud's PR analysis mode handles PR-specific comparison independently.

`release.yml` does not invoke SonarScanner, so no change is required there.

### Design notes

- `NuGetPackageVersion` is chosen over `SimpleVersion` because it includes the commit-height counter — needed so each master commit produces a unique version. `SimpleVersion` would only change when `version.json` is bumped, which would make every master commit look like the "same version" to SonarCloud.
- The new step (`Get NBGV version for SonarCloud`) is placed **after** the PR version override step so that PRs use their overridden version rather than the underlying master version.
- `dotnet tool restore` already runs earlier in the workflow, so `nbgv` is available without extra setup.

### Follow-up (not in this PR)

After this PR merges and the first post-fix master analysis records a version, a one-time admin task in SonarCloud will rebase the new-code window:

1. **New Code → Specific analysis →** pick the first post-fix master analysis → save.
2. Then switch back to **Previous version**.

This drops the 432 legacy smells out of the new-code window in one move. The 10 security hotspots will still need a manual triage in the Security Hotspots tab (all `LOW` probability — mostly legacy GitHub Actions SHA pinning and obsolete `azure-pipelines.yml` entries).

## Issue ticket number and link

Closes #222

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests. — *N/A, CI workflow change; verification is observing the next master build sets `sonar.projectVersion`*
- [ ] Do we need to implement analytics? — *N/A*
- [ ] Will this be part of a product update? — *N/A, internal CI plumbing*

## Summary by Sourcery

Ensure SonarCloud analyses use NBGV-generated versions by wiring the computed NuGet package version into the SonarScanner invocation in the .NET CI workflow.

CI:
- Capture NBGV's NuGetPackageVersion in the build-dotnet workflow and pass it to dotnet sonarscanner via the /v parameter so sonar.projectVersion is populated for SonarCloud analyses.

Documentation:
- Add a changelog entry describing the CI update to pass NBGV versions to SonarScanner and its impact on SonarCloud's new-code window.


___

## **CodeAnt-AI Description**
**Pass the build version to SonarCloud so the “Previous version” new-code check works**

### What Changed
- The dotnet build workflow now sends the current NBGV package version to SonarCloud during analysis.
- SonarCloud can now compare each run against the previous version instead of treating the full codebase as new code every time.
- The release workflow is unchanged because it does not run SonarScanner.

### Impact
`✅ Fewer false quality-gate failures`
`✅ Accurate new-code reporting on master`
`✅ Clearer SonarCloud results for PRs and releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
