### PR TITLE
chore(solution): Remove redundant <DocumentationFile> properties and gate PrintSettings target

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,8 +46,10 @@
         Optional MSBuild settings dump. Set `-p:PrintBuildSettings=true` on the dotnet CLI
         (or define the property in a Directory.Build.props override) to enable it for a
         targeted diagnostic build. Off by default so CI logs stay readable.
+        Also guarded against IDE design-time builds (IntelliSense/restore passes) so the
+        diagnostic dump never spams the IDE output even if the opt-in is set globally.
     -->
-    <Target Name="PrintSettings" BeforeTargets="Build" Condition="'$(PrintBuildSettings)' == 'true'">
+    <Target Name="PrintSettings" BeforeTargets="Build" Condition="'$(PrintBuildSettings)' == 'true' And '$(DesignTimeBuild)' != 'true'">
         <Message Text="Building $(MSBuildProjectName) with settings:" Importance="high" />
         <Message Text="MSBuildProjectName -> '$(MSBuildProjectName)'" Importance="high" />
         <Message Text="Configuration -> '$(Configuration)' " Importance="high" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,12 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <IsTestProject>false</IsTestProject>
     </PropertyGroup>
-    <Target Name="PrintSettings" BeforeTargets="Build">
+    <!--
+        Optional MSBuild settings dump. Set `-p:PrintBuildSettings=true` on the dotnet CLI
+        (or define the property in a Directory.Build.props override) to enable it for a
+        targeted diagnostic build. Off by default so CI logs stay readable.
+    -->
+    <Target Name="PrintSettings" BeforeTargets="Build" Condition="'$(PrintBuildSettings)' == 'true'">
         <Message Text="Building $(MSBuildProjectName) with settings:" Importance="high" />
         <Message Text="MSBuildProjectName -> '$(MSBuildProjectName)'" Importance="high" />
         <Message Text="Configuration -> '$(Configuration)' " Importance="high" />

--- a/change-log/2026-05-26-227-remove-redundant-documentationfile-and-printsettings.md
+++ b/change-log/2026-05-26-227-remove-redundant-documentationfile-and-printsettings.md
@@ -1,0 +1,36 @@
+## Remove redundant explicit `<DocumentationFile>` properties and gate `PrintSettings` target
+
+### Build configuration
+
+- **Removed `<DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>` from every library project.** The central `<GenerateDocumentationFile>true</GenerateDocumentationFile>` in `Directory.Build.props` (already in effect for all non-test projects) is sufficient on the modern .NET SDK — the SDK auto-generates the XML doc file next to the assembly and packs it into the `.nupkg`. The explicit per-project line was a pre-SDK-style holdover.
+- Affected projects: `Ploch.Common`, `Ploch.Common.AppServices`, `Ploch.Common.DawnGuard`, `Ploch.Common.DependencyInjection`, `Ploch.Common.Serialization`, `Ploch.Common.Serialiation.NewtonsoftJson`, `Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection`, `Ploch.Common.Serialization.SystemTextJson`, `Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection`, `Ploch.Common.WebUI`, `Ploch.TestingSupport`, `Ploch.TestingSupport.FluentAssertions`.
+- `Ploch.Common.Serialization` additionally had configuration-specific `<DocumentationFile>bin\Debug\…xml</DocumentationFile>` and `<DocumentationFile>bin\Release\…xml</DocumentationFile>` overrides; the entire Debug/Release `PropertyGroup`s collapsed to nothing once the property was removed and were deleted.
+
+### Test-fixture assemblies
+
+- `Ploch.Common.Tests.TestAssembly1` and `Ploch.Common.Tests.TestAssembly2` are not auto-detected as test projects by the `MSBuildProjectName.EndsWith('Tests')` rule (their names end in `TestAssembly1`/`2`). They previously used `<DocumentationFile />` (empty) inside Debug/Release `PropertyGroup`s as a workaround to suppress the centrally-enabled XML doc generation. Replaced with a single explicit `<GenerateDocumentationFile>false</GenerateDocumentationFile>` to mirror the test-project convention — these are fixture assemblies used only for reflection-based tests and never published.
+
+### Build log noise
+
+- **Gated the `PrintSettings` debug `<Target>` behind a `PrintBuildSettings` opt-in property.** Previously it emitted ~10 `Importance="high"` `<Message>` lines on every build of every project, padding CI logs with ~270 lines per full build (27 projects × 10 messages). Now off by default; enable for a targeted diagnostic build with `-p:PrintBuildSettings=true`.
+
+### Documentation
+
+- Updated `docs/libraries/common-msbuild.md` § "Build Diagnostics Target" to describe the new opt-in behaviour and the enable command.
+
+### Why
+
+Surfaced while reviewing #117 (Feb 2024 stale PR that tried to *change* `<DocumentationFile>` to use `$(BaseOutputPath)` — that path drops the TFM subfolder, so multi-targeted projects would have collided both inner builds' XML doc onto one path). #117 was closed; this issue tracks the *correct* cleanup: remove the redundant property entirely rather than tweaking its value.
+
+The `PrintSettings` target was useful when diagnosing the unexpected build behaviour that motivated the central `GenerateDocumentationFile=true` switch (see issue #117 history), but on a clean configuration it adds only log noise. Gating it behind `PrintBuildSettings` preserves the diagnostic capability for on-demand use without polluting every CI build.
+
+### Out of scope
+
+- DocFX-driven API site (`DocumentationSite/docfx.json`) is unaffected — it extracts metadata from `*.csproj` source via Roslyn, not from `bin/*.xml`. The published site at <https://common.github.ploch.dev/> continues to work.
+- Several library `.csproj` files still carry `<None Remove="Ploch.<Name>.xml" />` items. These were companion workarounds for the explicit `<DocumentationFile>` paths; with the SDK now writing XML to the intermediate output directory they are likely no-ops, but verifying and removing them is a follow-up cleanup, not part of this issue's scope.
+- `templates/Directory.Build.props` is a frozen legacy template (uses the pre-NBGV `VersionPrefix`/`BuildNumber` pattern) and was not modified.
+
+### Verification
+
+- `dotnet build Ploch.Common.slnx -c Release` — zero new warnings, zero errors. CI logs no longer contain per-project `PrintSettings` dumps.
+- Each library `.nupkg` continues to ship `lib/<tfm>/<Assembly>.xml` per target framework (the SDK auto-derives the path from `GenerateDocumentationFile=true`).

--- a/change-log/2026-05-26-227-remove-redundant-documentationfile-and-printsettings.md
+++ b/change-log/2026-05-26-227-remove-redundant-documentationfile-and-printsettings.md
@@ -24,10 +24,14 @@ Surfaced while reviewing #117 (Feb 2024 stale PR that tried to *change* `<Docume
 
 The `PrintSettings` target was useful when diagnosing the unexpected build behaviour that motivated the central `GenerateDocumentationFile=true` switch (see issue #117 history), but on a clean configuration it adds only log noise. Gating it behind `PrintBuildSettings` preserves the diagnostic capability for on-demand use without polluting every CI build.
 
+### Follow-ups picked up during review
+
+- **Orphaned `<None Remove="*.xml" />` directives.** The original cleanup left companion `<None Remove="Ploch.<Name>.xml" />` items in six library `.csproj` files (`Ploch.Common`, `Ploch.Common.AppServices`, `Ploch.Common.AppServices.Web`, `Ploch.Common.Serialization.SystemTextJson`, `Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection`, `Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection`). The SDK writes the XML doc to `bin/<tfm>/` (not the project source root), so the default `<None>` glob never picked them up and the Remove directives have been no-ops since the SDK switch. Flagged by Bito review; swept in a follow-up commit on this PR.
+- **Design-time build guard on `PrintSettings`.** Gemini Code Assist suggested extending the opt-in condition with `And '$(DesignTimeBuild)' != 'true'` so the diagnostic dump never fires during IDE IntelliSense / restore passes even if `PrintBuildSettings=true` is set globally (env var / system `Directory.Build.props` override). Applied.
+
 ### Out of scope
 
 - DocFX-driven API site (`DocumentationSite/docfx.json`) is unaffected — it extracts metadata from `*.csproj` source via Roslyn, not from `bin/*.xml`. The published site at <https://common.github.ploch.dev/> continues to work.
-- Several library `.csproj` files still carry `<None Remove="Ploch.<Name>.xml" />` items. These were companion workarounds for the explicit `<DocumentationFile>` paths; with the SDK now writing XML to the intermediate output directory they are likely no-ops, but verifying and removing them is a follow-up cleanup, not part of this issue's scope.
 - `templates/Directory.Build.props` is a frozen legacy template (uses the pre-NBGV `VersionPrefix`/`BuildNumber` pattern) and was not modified.
 
 ### Verification

--- a/docs/libraries/common-msbuild.md
+++ b/docs/libraries/common-msbuild.md
@@ -181,7 +181,13 @@ All analyser packages are configured with `PrivateAssets=all` so they are build-
 
 ## Build Diagnostics Target
 
-`Directory.Build.props` includes a `PrintSettings` target that runs before every build and logs key MSBuild property values at high importance. This aids in diagnosing unexpected build behaviour in CI:
+`Directory.Build.props` includes an opt-in `PrintSettings` target that logs key MSBuild property values at high importance before each project builds. It is gated behind the `PrintBuildSettings` property and is off by default so CI logs stay readable. Enable it for a targeted diagnostic build:
+
+```bash
+dotnet build Ploch.Common.slnx -p:PrintBuildSettings=true
+```
+
+Sample output:
 
 ```text
 Building Ploch.Common with settings:

--- a/src/Common.AppServices.Web/Ploch.Common.AppServices.Web.csproj
+++ b/src/Common.AppServices.Web/Ploch.Common.AppServices.Web.csproj
@@ -29,7 +29,6 @@
 
     <ItemGroup>
         <None Include=".\README.md" Pack="true" PackagePath="\" />
-        <None Remove="Ploch.Common.AppServices.Web.xml" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Common.AppServices/Ploch.Common.AppServices.csproj
+++ b/src/Common.AppServices/Ploch.Common.AppServices.csproj
@@ -14,7 +14,6 @@
 
     <ItemGroup>
         <None Include=".\README.md" Pack="true" PackagePath="\" />
-        <None Remove="Ploch.Common.AppServices.xml" />
     </ItemGroup>
 
 </Project>

--- a/src/Common.AppServices/Ploch.Common.AppServices.csproj
+++ b/src/Common.AppServices/Ploch.Common.AppServices.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
         <Title>Ploch.Common.AppServices Library</Title>
         <Description>Ploch.Common.AppServices, part of Ploch.Common utility library, provides interfaces for common application services that can be implemented by various providers.</Description>
         <PackageTags>common;utility;common-library;core</PackageTags>

--- a/src/Common.DawnGuard/Ploch.Common.DawnGuard.csproj
+++ b/src/Common.DawnGuard/Ploch.Common.DawnGuard.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Common.DependencyInjection/Ploch.Common.DependencyInjection.csproj
+++ b/src/Common.DependencyInjection/Ploch.Common.DependencyInjection.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Platforms>AnyCPU;x64</Platforms>
     </PropertyGroup>

--- a/src/Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection.csproj
+++ b/src/Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection.csproj
@@ -13,6 +13,5 @@
     </ItemGroup>
     <ItemGroup>
         <None Include=".\README.md" Pack="true" PackagePath="\" />
-        <None Remove="Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection.xml" />
     </ItemGroup>
 </Project>

--- a/src/Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection.csproj
+++ b/src/Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Common.Serialization.NewtonsoftJson/Ploch.Common.Serialiation.NewtonsoftJson.csproj
+++ b/src/Common.Serialization.NewtonsoftJson/Ploch.Common.Serialiation.NewtonsoftJson.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Common.Serialization.SystemTextJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection.csproj
+++ b/src/Common.Serialization.SystemTextJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection.csproj
@@ -11,6 +11,5 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <None Include=".\README.md" Pack="true" PackagePath="\" />
-        <None Remove="Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection.xml" />
     </ItemGroup>
 </Project>

--- a/src/Common.Serialization.SystemTextJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection.csproj
+++ b/src/Common.Serialization.SystemTextJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Platforms>AnyCPU;x64</Platforms>
     </PropertyGroup>

--- a/src/Common.Serialization.SystemTextJson/Ploch.Common.Serialization.SystemTextJson.csproj
+++ b/src/Common.Serialization.SystemTextJson/Ploch.Common.Serialization.SystemTextJson.csproj
@@ -13,6 +13,5 @@
     </ItemGroup>
     <ItemGroup>
         <None Include=".\README.md" Pack="true" PackagePath="\" />
-        <None Remove="Ploch.Common.Serialization.SystemTextJson.xml" />
     </ItemGroup>
 </Project>

--- a/src/Common.Serialization.SystemTextJson/Ploch.Common.Serialization.SystemTextJson.csproj
+++ b/src/Common.Serialization.SystemTextJson/Ploch.Common.Serialization.SystemTextJson.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Platforms>AnyCPU;x64</Platforms>
     </PropertyGroup>

--- a/src/Common.Serialization/Ploch.Common.Serialization.csproj
+++ b/src/Common.Serialization/Ploch.Common.Serialization.csproj
@@ -1,15 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DocumentationFile>bin\Debug\Ploch.Common.Serialization.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DocumentationFile>bin\Release\Ploch.Common.Serialization.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dawn.Guard" />

--- a/src/Common.WebUI/Ploch.Common.WebUI.csproj
+++ b/src/Common.WebUI/Ploch.Common.WebUI.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/src/Common/Ploch.Common.csproj
+++ b/src/Common/Ploch.Common.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
         <Title>Ploch.Common Library</Title>
 
         <Description>Utility and extension methods for the core .NET types and common development tasks.</Description>

--- a/src/Common/Ploch.Common.csproj
+++ b/src/Common/Ploch.Common.csproj
@@ -49,6 +49,5 @@
     </ItemGroup>
     <ItemGroup>
         <None Include=".\README.md" Pack="true" PackagePath="\" />
-        <None Remove="Ploch.Common.xml" />
     </ItemGroup>
 </Project>

--- a/src/TestingSupport.FluentAssertions/Ploch.TestingSupport.FluentAssertions.csproj
+++ b/src/TestingSupport.FluentAssertions/Ploch.TestingSupport.FluentAssertions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>

--- a/src/TestingSupport/Ploch.TestingSupport.csproj
+++ b/src/TestingSupport/Ploch.TestingSupport.csproj
@@ -4,7 +4,6 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Kris Ploch</Authors>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/TestAssemblies/Common.Tests.TestAssembly1/Ploch.Common.Tests.TestAssembly1.csproj
+++ b/tests/TestAssemblies/Common.Tests.TestAssembly1/Ploch.Common.Tests.TestAssembly1.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,15 +6,8 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DocumentationFile />
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DocumentationFile />
   </PropertyGroup>
 
 </Project>

--- a/tests/TestAssemblies/Common.Tests.TestAssembly2/Ploch.Common.Tests.TestAssembly2.csproj
+++ b/tests/TestAssemblies/Common.Tests.TestAssembly2/Ploch.Common.Tests.TestAssembly2.csproj
@@ -1,19 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DocumentationFile />
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DocumentationFile />
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Describe your changes

Cleans up two pieces of build-config cruft surfaced in #227:

1. **Removes the explicit `<DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>` property** from every library `.csproj` (12 files). The modern .NET SDK already generates and packs the XML doc next to the assembly when the central `<GenerateDocumentationFile>true</GenerateDocumentationFile>` (declared in `Directory.Build.props` for all non-test projects) is in effect. The explicit per-project line is a pre-SDK-style holdover.
2. **Gates the `PrintSettings` debug `<Target>` behind an opt-in `PrintBuildSettings` property** so it no longer fires by default. Previously it dumped ~10 high-importance `<Message>` lines per project on every build — roughly 270 lines per full solution build, padding CI logs unhelpfully. Also guarded against IDE design-time builds (per gemini-code-assist review) so the dump never spams IntelliSense / restore passes even if the opt-in is set globally.

### File-level changes

- `Directory.Build.props` — adds `Condition="'$(PrintBuildSettings)' == 'true' And '$(DesignTimeBuild)' != 'true'"` to the `PrintSettings` target plus an explanatory comment.
- 12 library `.csproj` files — drop the redundant `<DocumentationFile>` line: `Ploch.Common`, `Ploch.Common.AppServices`, `Ploch.Common.DawnGuard`, `Ploch.Common.DependencyInjection`, `Ploch.Common.Serialization`, `Ploch.Common.Serialiation.NewtonsoftJson`, `Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection`, `Ploch.Common.Serialization.SystemTextJson`, `Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection`, `Ploch.Common.WebUI`, `Ploch.TestingSupport`, `Ploch.TestingSupport.FluentAssertions`.
- `src/Common.Serialization/Ploch.Common.Serialization.csproj` — additionally drops the two configuration-specific `<DocumentationFile>bin\Debug|Release\…xml</DocumentationFile>` overrides; the resulting empty Debug/Release `PropertyGroup`s are deleted.
- `tests/TestAssemblies/Common.Tests.TestAssembly1/...csproj`, `Common.Tests.TestAssembly2/...csproj` — these are fixture assemblies not auto-detected as test projects (their names end in `TestAssemblyN`, not `Tests`). Replaced the `<DocumentationFile />` (empty) workaround with explicit `<GenerateDocumentationFile>false</GenerateDocumentationFile>` to mirror the test-project convention; they are never published and do not need an XML doc.
- 6 library `.csproj` files — orphaned `<None Remove="Ploch.<Name>.xml" />` directives swept (companions to the now-removed explicit `<DocumentationFile>` paths; the SDK writes XML to `bin/<tfm>/` not the project source root, so the default `<None>` glob never picked them up and these Remove items have been no-ops since the SDK switch). Affected: `Ploch.Common`, `Ploch.Common.AppServices`, `Ploch.Common.AppServices.Web`, `Ploch.Common.Serialization.SystemTextJson`, `Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection`, `Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection`.
- `docs/libraries/common-msbuild.md` — refreshed the *Build Diagnostics Target* section to describe the new opt-in behaviour and the enable command (`dotnet build -p:PrintBuildSettings=true`).
- `change-log/2026-05-26-227-remove-redundant-documentationfile-and-printsettings.md` — added.

## Design decisions

- **Gate, do not delete, `PrintSettings`** — the issue offered both options. Keeping it as an opt-in preserves the diagnostic capability for on-demand local triage (or `dotnet build -p:PrintBuildSettings=true` in a CI rerun) without polluting every build. Zero recurring noise, one MSBuild condition to remember.
- **Guard against design-time builds** (added during review per gemini-code-assist suggestion) — `'$(DesignTimeBuild)' != 'true'` prevents the diagnostic dump from spamming IDE output when `PrintBuildSettings=true` is set globally via env var or a system-level `Directory.Build.props` override.
- **TestAssemblies → explicit `GenerateDocumentationFile=false`** — they are not packed (`IsPackable=false`) and exist only as reflection targets, so they do not need an XML doc. Setting it once at the top of the `PropertyGroup` is cleaner than the prior pattern of empty `<DocumentationFile />` inside Debug/Release-specific `PropertyGroup`s. The central `GenerateDocumentationFile=false` in `Directory.Build.props` does **not** apply to these projects because they fail the `MSBuildProjectName.EndsWith('Tests')` test (their names end in `TestAssembly1` / `TestAssembly2`), so the override here is required, not redundant.
- **Sweep the `<None Remove="*.xml" />` orphans in this PR** (originally deferred as a follow-up; pulled in after Bito flagged one) — the cleanup is one line per file and removes dead code that the SDK switch made obsolete. Verified `dotnet pack` on `Ploch.Common` still produces `lib/net8.0/Ploch.Common.xml` and `lib/netstandard2.0/Ploch.Common.xml` after removal.
- **`templates/Directory.Build.props` left untouched** — it is a frozen legacy template (still uses the pre-NBGV `VersionPrefix`/`BuildNumber` pattern) and is not consumed by the live build.

## Issue ticket number and link

Closes #227.

## Testing

- **Local Release build:** `dotnet build Ploch.Common.slnx -c Release` — 0 errors, 0 *new* warnings. The 818 build warnings present are all pre-existing diagnostics in `tests/Common.Tests/...` (S1144, IDE0290, SA1122, CA2263, etc.); this PR touches no `.cs` files, so it cannot introduce any.
- **CI log noise:** Default-config rebuild emits no `Building <X> with settings: …` lines anywhere; targeted opt-in (`dotnet build -p:PrintBuildSettings=true`) re-enables them as expected.
- **`.nupkg` shape:** `dotnet pack src/Common/Ploch.Common.csproj` produces `Ploch.Common.<version>.nupkg` containing `lib/net8.0/Ploch.Common.xml` and `lib/netstandard2.0/Ploch.Common.xml` — one XML doc per TFM, as before.
- **Unit & integration tests:** Full `dotnet test Ploch.Common.slnx -c Release --no-build` — every suite green (`Ploch.Common.Tests` 812/812 on net10 and 774/774 on net8; `Ploch.TestingSupport.XUnit3.Tests` 207/207; all serialization-DI tests 100% pass). Skipped tests are pre-existing macOS-platform-only cases.
- **CI bots:** all 13 PR checks pass (build, qodana, Codacy ×4, CodeQL Python, CodeRabbit, Sourcery, DeepSource, SonarCloud, Bito, CodeFactor, Test Results). All review threads (4) resolved with on-thread replies. SonarCloud platform query: zero open issues, zero security hotspots, quality gate `OK` with zero new code smells.
- **DocFX site:** Out of scope by design (the site renders metadata from `*.csproj` source via Roslyn, not from `bin/*.xml`). No site re-deploy needed for this PR.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. *(Build-config cleanup — covered by existing test suite + manual `dotnet pack` inspection.)*
- [x] Do we need to implement analytics? *No.*
- [x] Will this be part of a product update? *Build-infrastructure change only — no consumer-visible API or behaviour change.* 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR cleans up two pieces of build-configuration cruft in a .NET SDK-style solution. First, it removes redundant explicit <DocumentationFile> properties from 10 library csproj files (plus Ploch.Common.Serialization.csproj which also had Debug/Release-specific overrides) since the central <GenerateDocumentationFile>true</GenerateDocumentationFile> in Directory.Build.props already handles this. Second, it gates the PrintSettings MSBuild target behind an opt-in PrintBuildSettings property so it no longer emits ~270 diagnostic lines per full solution build by default.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Gates the PrintSettings target in Directory.Build.props behind Condition="'$(PrintBuildSettings)' == 'true' And '$(DesignTimeBuild)' != 'true'" to eliminate ~270 diagnostic lines per full build and prevents IDE design-time build spam when opt-in is set globally.</li>

<li>Removes explicit <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile> from 10 library csproj files and removes Debug/Release-specific PropertyGroup overrides from Ploch.Common.Serialization.csproj.</li>

<li>Removes obsolete <None Remove="Ploch.<Name>.xml" /> directives from 6 library csproj files (no-ops since SDK writes XML to bin/<tfm>/).</li>

<li>Adds explicit <GenerateDocumentationFile>false</GenerateDocumentationFile> to the two test fixture assemblies (Ploch.Common.Tests.TestAssembly1 and TestAssembly2), replacing the prior Debug/Release empty <DocumentationFile /> workaround.</li>

<li>Updates docs/libraries/common-msbuild.md to document the new opt-in behaviour and adds a changelog entry for issue #227.</li>

</ul>
</details>

</div>