### PR TITLE
docs(readme): Add rel="noopener noreferrer" to Buy Me a Coffee anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Ploch.Common is a suite of .NET libraries targeting `netstandard2.0` and `net8.0
 If `Ploch.Common` saves you time or makes your projects nicer, please consider supporting its development. Every coffee directly funds time spent on maintenance, bug fixes, and new features.
 
 <p align="center">
-  <a href="https://buymeacoffee.com/krisploch" target="_blank">
+  <a href="https://buymeacoffee.com/krisploch" target="_blank" rel="noopener noreferrer">
     <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee — krisploch" height="60" width="217" />
   </a>
 </p>

--- a/change-log/2026-05-27-229-readme-noopener-noreferrer.md
+++ b/change-log/2026-05-27-229-readme-noopener-noreferrer.md
@@ -1,0 +1,20 @@
+## Docs: Add `rel="noopener noreferrer"` to Buy Me a Coffee anchor
+
+### Changed
+
+- `README.md` — the Buy Me a Coffee anchor in the `## Support the Project` section now sets `rel="noopener noreferrer"` alongside `target="_blank"`.
+
+### Why
+
+Anchors with `target="_blank"` should set `rel="noopener noreferrer"` to defend against reverse tabnabbing: without `noopener`, the opened page can access `window.opener` in the original tab and silently navigate it (e.g. to a phishing destination). Modern browsers default to `noopener` for `target="_blank"`, but the explicit attribute survives renderer differences across GitHub, NuGet, and other README renderers, and matches the safe-link pattern documented by MDN and OWASP.
+
+Caught by `gemini-code-assist` while reviewing the equivalent change in `ploch-data` (mrploch/ploch-data#86 → mrploch/ploch-data#89). Brings the `ploch-common` README in line with `ploch-data`.
+
+### Impact
+
+Documentation-only. No code change, no behaviour change, no breaking change.
+
+### Refs
+
+- #229 (docs(readme): Add rel="noopener noreferrer" to Buy Me a Coffee anchor)
+- Mirrors mrploch/ploch-data#89


### PR DESCRIPTION
## **User description**
## Describe your changes

Adds `rel="noopener noreferrer"` to the Buy Me a Coffee anchor in `README.md` (`## Support the Project` section), so the anchor matches the documented safe-link pattern for `target="_blank"` links.

### Why

Anchors with `target="_blank"` should set `rel="noopener noreferrer"` to defend against reverse tabnabbing — without `noopener`, the opened page can access `window.opener` in the original tab and silently navigate it (e.g. to a phishing destination). Modern browsers default to `noopener` for `target="_blank"` since 2021, but the explicit attribute survives renderer differences across GitHub, NuGet, and other README renderers where the browser default may not be applied.

### Changes

- `README.md` — Buy Me a Coffee anchor now sets `rel="noopener noreferrer"` alongside `target="_blank"`.
- `change-log/2026-05-27-229-readme-noopener-noreferrer.md` — documents the change for the next release.

### Design decisions

- Followed the exact pattern landed in `mrploch/ploch-data#89`, so the two READMEs stay consistent.
- No `.codacy.yml` change was needed in this repository: `ploch-common`'s README already contains the inline-HTML `<p>/<a>/<img>` block from a prior change, so the markdownlint MD033 surface is unchanged by this PR. `ploch-data#89` had to touch `.codacy.yml` because that PR was the first to introduce inline HTML in its README.

### Testing

- Documentation-only — no code change, no behaviour change, no breaking change. No automated tests apply.
- Verified the diff is a single attribute addition on one line.
- Confirmed there are no other `target="_blank"` anchors in any `.md` in the repository that would need the same fix.

## Issue ticket number and link

Closes #229

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests. _(N/A — docs only)_
- [ ] Do we need to implement analytics? _(N/A — docs only)_
- [ ] Will this be part of a product update? If yes, please write one phrase about this update. _(N/A — docs only)_

## Summary by Sourcery

Update documentation to harden the external support link and record the change for release notes.

Documentation:
- Add `rel="noopener noreferrer"` to the Buy Me a Coffee link in the README to follow the recommended pattern for `target="_blank"` links.
- Document the README security hardening in a new changelog entry for the upcoming release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved security on external links by adding protective link attributes to prevent reverse tabnabbing attacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mrploch/ploch-common/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add a safer external support link in the README**

### What Changed
- The Buy Me a Coffee link in the README now includes `rel="noopener noreferrer"` when opening in a new tab
- A changelog entry was added to record the documentation update

### Impact
`✅ Safer new-tab links`
`✅ Lower reverse-tabnabbing risk`
`✅ Clearer release notes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
