### PR TITLE
chore(common): Ignore local last-session.ps1 helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -436,6 +436,7 @@ identifier.sqlite
 !.claude/rules/todo-tasks-execution.md
 
 # Local research/scratch files
+last-session.ps1
 Writerside2.iml
 Writerside2/
 pdfSourceP.html


### PR DESCRIPTION
## Describe your changes

Add `last-session.ps1` to `.gitignore` (under the "Local research/scratch files" section). It's a local developer helper script, not part of the project, and was at risk of being accidentally staged/committed.

## Testing

`.gitignore`-only change. Verified `git check-ignore last-session.ps1` now matches, and the file no longer appears in `git status`. No code touched.

## Issue ticket number and link

Closes #240

## Summary by Sourcery

Build:
- Update .gitignore to ignore last-session.ps1 as a local development helper script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude a new local scratch/config file from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->