### PR TITLE
test(common): Clean up pre-existing analyzer warnings in test projects

### DIFF
--- a/change-log/2026-06-28-233-test-analyzer-warning-cleanup.md
+++ b/change-log/2026-06-28-233-test-analyzer-warning-cleanup.md
@@ -1,0 +1,32 @@
+## Test projects: clean up pre-existing analyzer warnings
+
+Removed the entire backlog of pre-existing analyzer warnings across the test
+projects so that future regressions stand out in the build output. The
+test-project warning count went from **~814 to 0**; the build is now clean for
+every test assembly.
+
+This is a **test-only** change — no shipping-library (`src/`) code was modified,
+so there is no consumer-visible behaviour change. The equivalent cleanup for the
+shipping libraries is tracked separately in **#242**.
+
+### Approach (per the issue's "balanced" policy)
+
+- **Real in-code fixes** were preferred over suppressions. Examples: genuine bugs
+  surfaced by the analysers were fixed — a malformed `#pragma` (CS1696), a
+  `FluentAssertions` argument-count mismatch (CA2241), a reference-vs-value
+  comparison that should have been a string cast (CS0252), a redundant
+  `== true` (S1125), and a duplicate test method (S4144). Other fixes were
+  mechanical: `nameof(...)` over string literals, `var` usage, `string.Empty`
+  over `""`, member-group conversions, ordering, comment spacing, dead-code and
+  redundant-local removal, and consistent collection-initialiser indentation.
+- **Analyzer config scoping** (in `tests/.editorconfig`, with justifying
+  comments) was used **only** for rules that are inherently inapplicable to
+  non-shipping test assemblies — e.g. XML-doc rules, argument-validation rules,
+  async-suffix/threading rules, and a small set of rules that fire as false
+  positives on deliberately-shaped reflection/serialization test fixtures (whose
+  "smells" are the subject under test, not accidental misuse). The scoping lives
+  in the nested `tests/.editorconfig` so it never affects `src/` analysis.
+
+### Refs
+
+- #233

--- a/src/Common.WebUI.Tests/GlobalUsings.cs
+++ b/src/Common.WebUI.Tests/GlobalUsings.cs
@@ -1,3 +1,3 @@
-global using Xunit;
 global using FluentAssertions;
 global using Ploch.TestingSupport.XUnit3.AutoMoq;
+global using Xunit;

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -22,8 +22,14 @@ dotnet_diagnostic.cs8600.severity = suggestion # Converting null literal or poss
 dotnet_diagnostic.cs8603.severity = suggestion # Possible null reference return
 dotnet_diagnostic.cs8604.severity = suggestion # Possible null reference argument for parameter.
 
-dotnet_diagnostic.IDE0051.severity = warning # Remove unused private members
-dotnet_diagnostic.IDE0052.severity = warning # Remove unused private members
+# IDE0051/IDE0052 were previously 'warning' for test code, but this suite is dominated by
+# reflection/serialization fixtures whose private members are only ever read via reflection;
+# static analysis reports them as unused/unread (false positives). Per issue #233 these are
+# scoped off for test code rather than removed (removal would break the tests) or suppressed
+# per-line. Trade-off: a genuinely-dead private member in future test logic will no longer be
+# flagged at build time. See the "issue #233" block at the end of this file for the full set.
+dotnet_diagnostic.IDE0051.severity = none # Remove unused private member - reflection fixtures (see #233)
+dotnet_diagnostic.IDE0052.severity = none # Remove unread private member - reflection fixtures (see #233)
 
 # SonarAnalyzer settings
 dotnet_diagnostic.s4487.severity = none # Unread "private" fields should be removed
@@ -63,3 +69,151 @@ dotnet_naming_symbols.unity_serialized_field_symbols.resharper_required_modifier
 resharper_lambda_expression_can_be_made_static_highlighting = none
 
 resharper_possible_multiple_enumeration_highlighting = none
+
+# =====================================================================================
+# Test-project analyzer scoping (issue #233)
+# -------------------------------------------------------------------------------------
+# Test assemblies are never published as NuGet packages and form no part of any public
+# API surface. The rules below target shipping-library concerns (public-API hygiene,
+# documentation, micro-performance, async-naming conventions) or describe deliberately-
+# shaped reflection/serialization fixtures - in both cases they add noise without value
+# in test code. They are scoped down here, for test projects only; the same rules remain
+# fully active for src/ library code. Library (src/) warnings are tracked in issue #242.
+#
+# This block deliberately does NOT silence rules that catch real defects in test logic
+# (unused locals, redundant code, format-string bugs, reference comparisons, string.Empty,
+# nameof, member ordering, etc.) - those are fixed in code per #233's "prefer real fixes".
+# =====================================================================================
+
+# -- Documentation: test code is not documented (GenerateDocumentationFile=false) --
+dotnet_diagnostic.sa1602.severity = none # Enumeration items should be documented - test enums are not public API
+dotnet_diagnostic.sa1648.severity = none # inheritdoc should be used with inheriting class - test types are not documented
+
+# -- Async / lifecycle conventions that do not apply to xUnit test & fixture code --
+dotnet_diagnostic.vsthrd200.severity = none # "Async" suffix - xUnit discovers test methods by attribute, not name
+dotnet_diagnostic.vsthrd103.severity = none # Call async methods - synchronous Dispose in test teardown is acceptable
+dotnet_diagnostic.s6966.severity = none # Await DisposeAsync - same rationale as VSTHRD103 for test lifecycle teardown
+dotnet_diagnostic.ag0023.severity = none # Thread.Sleep - legitimately used to exercise timing/concurrency behaviour in tests
+
+# -- Globalisation: test inputs are fixed, deterministic literals; culture is irrelevant --
+dotnet_diagnostic.ca1305.severity = none # Specify IFormatProvider - test string building uses deterministic data
+
+# -- Exceptions: tests routinely throw/expect the base exception type to simulate failures --
+dotnet_diagnostic.ca2201.severity = none # Do not raise reserved exception types - tests throw System.Exception to simulate failures
+# Private, test-internal helper exception types (e.g. ExceptionWithNullMessage in ErrorInfoTests)
+# are never part of any public API surface, so shipping-exception visibility/naming conventions
+# do not apply to them.
+dotnet_diagnostic.s3871.severity = none # Exception should be public - test-internal helper exceptions are private by design
+dotnet_diagnostic.s3376.severity = none # Name should end with 'Exception' - test-internal helper exceptions
+
+# -- Tests deliberately combine non-[Flags] enum values (e.g. DayOfWeek.Monday | DayOfWeek.Wednesday)
+# to exercise flag-handling extension methods such as GetFlags(); the bitwise operation is the
+# subject under test, not an accidental misuse. --
+dotnet_diagnostic.s3265.severity = none # Bitwise operation on non-[Flags] enum - intentional in flag-handling tests
+
+# -- False positive on collection expressions passed as a NAMED params argument: when a record/method
+# has leading optional parameters before its params parameter (e.g. TypeLoadingConfiguration), the
+# collection MUST be supplied via a named argument (BaseTypes: [ ... ]) and cannot use params-expansion
+# syntax, so the array/collection creation cannot be removed. --
+dotnet_diagnostic.s3878.severity = none # Remove array creation and pass elements - not possible for named params arguments
+
+# -- Micro-performance: irrelevant in test code --
+dotnet_diagnostic.ca1859.severity = none # Use concrete types for performance - not a concern in tests
+dotnet_diagnostic.ca1861.severity = none # Avoid constant arrays as arguments - not a concern in tests
+dotnet_diagnostic.ca1852.severity = none # Seal internal types - test classes/fixtures are commonly inherited; perf is irrelevant
+
+# -- Static-member suggestions: test/fixture instance members must remain instance for xUnit --
+dotnet_diagnostic.ca1822.severity = none # Mark members as static - xUnit fixtures and reflection targets must stay instance members
+dotnet_diagnostic.s2325.severity = none # Make method/property static - same rationale as CA1822
+
+# -- Public-API design rules meaningless for non-shipping assemblies --
+dotnet_diagnostic.ag0018.severity = none # Publicly exposed IEnumerable - test types are not a consumed public API
+
+# -- Tests deliberately exercise deprecated/obsolete APIs to verify their behaviour --
+dotnet_diagnostic.cs0618.severity = none # Obsolete member usage - tests verify behaviour of deprecated APIs
+
+# -- Generic-overload preference: tests deliberately exercise the non-generic, Type-accepting
+# overloads of these APIs (e.g. JsonSerializer.Convert(Type, object), TypeGuards.AssignableTo(Type),
+# AppDomainTypesLoader.GetTypesImplementing(Type), Randomizer.GetRandomizer(Type)). Several tests
+# are explicitly named *_NotGeneric or are paired with a separate generic test; rewriting them to
+# the generic overload would no longer cover the non-generic code path. --
+dotnet_diagnostic.ca2263.severity = none # Prefer generic overload - tests intentionally cover the non-generic overloads
+
+# -- Member ordering is not enforced in test code, consistent with the pre-existing
+# 'sa1201.severity = none' (Elements should appear in the correct order) above. --
+dotnet_diagnostic.sa1202.severity = none # 'public' members should come before 'protected'/'private' - ordering not enforced in tests
+dotnet_diagnostic.sa1204.severity = none # Static members should appear before non-static members - ordering not enforced in tests
+
+# -- Style preference not enforced in tests --
+dotnet_diagnostic.ide0290.severity = none # Use primary constructor - fixtures and test classes vary; not enforced in tests
+
+# -- TODO comments stay visible in the IDE but do not fail the build --
+dotnet_diagnostic.s1135.severity = suggestion # Complete the task associated to this TODO - informational in test code
+
+# -- Crashing analyzer: StyleCop SA1508 throws a NullReferenceException on some test files,
+# surfaced as a file-less "CSC : warning AD0001". AD0001 cannot be configured via .editorconfig
+# (it has no associated source file), so the root cause is addressed instead: SA1508 is
+# disabled for test code, which makes Roslyn skip the analyzer for test-project compilations -
+# no execution, no crash, no AD0001. SA1508 remains enabled (severity=warning) for src/.
+dotnet_diagnostic.sa1508.severity = none # Closing brace should not be preceded by blank line - analyzer NRE on test files (see #233)
+
+# -------------------------------------------------------------------------------------
+# Reflection / serialization test-fixture shapes
+# -------------------------------------------------------------------------------------
+# Across this test suite (the dedicated tests/TestAssemblies/ projects AND fixture types
+# nested directly inside *.Tests files such as ObjectReflectionExtensionsTests,
+# TypeExtensionsTests, GuardFlagsEnumTests) there are types whose ENTIRE PURPOSE is to be
+# an awkwardly-shaped reflection/serialization target: public mutable fields, write-only
+# properties, members read only via reflection, enums and attributes with deliberately
+# unconventional names, generic type parameters declared to test type-loading, and so on.
+# "Fixing" these (renaming, removing "unused" members, making fields private) would break
+# the very tests that reflect over the shapes - the member IS used, just not in a way
+# static analysis can see. These rules remain fully active for src/ library code.
+
+# Field accessibility / mutability - fixtures expose fields of every shape for reflection
+dotnet_diagnostic.ca1051.severity = none # Do not declare visible instance fields
+dotnet_diagnostic.s1104.severity = none # Fields should not have public accessibility
+dotnet_diagnostic.sa1401.severity = none # Fields should be private
+dotnet_diagnostic.s2223.severity = none # Change visibility or make const/readonly
+dotnet_diagnostic.ca2211.severity = none # Non-constant fields should not be visible
+dotnet_diagnostic.s2933.severity = none # Make field readonly - fixtures are mutated/inspected via reflection
+
+# Type, enum and generic design - deliberately unconventional fixture shapes
+dotnet_diagnostic.ca1711.severity = none # Identifiers should not have incorrect suffix (e.g. ByteEnum)
+dotnet_diagnostic.s2344.severity = none # Enum name should not have 'Enum' suffix
+dotnet_diagnostic.s101.severity = none # Type name should match pascal case (e.g. Attribute1_1Attribute)
+dotnet_diagnostic.s2326.severity = none # Unused type parameter - fixtures test generic type loading
+dotnet_diagnostic.s3400.severity = none # Method should be replaced with a constant - fixture surface
+
+# Property shapes exercised by reflection tests
+dotnet_diagnostic.s2376.severity = none # Write-only property - fixture exercises write-only reflection
+dotnet_diagnostic.s2292.severity = none # Use auto-property - fixture deliberately uses a backing field
+
+# Custom test attributes
+dotnet_diagnostic.s3993.severity = none # Specify AttributeUsage - fixture attributes test attribute discovery
+dotnet_diagnostic.rcs1203.severity = none # Use AttributeUsageAttribute
+dotnet_diagnostic.ca1018.severity = none # Specify AttributeUsage on attribute
+dotnet_diagnostic.cc0023.severity = none # Mark attribute as sealed
+
+# Class design of fixture/utility types
+dotnet_diagnostic.rcs1102.severity = none # Make class static - fixtures are instantiated/reflected
+dotnet_diagnostic.s1118.severity = none # Add private constructor or static - fixture surface
+
+# "Unused" members are reflection targets that static analysis cannot see being used
+# (IDE0051/IDE0052 are set to none above, near the original declarations)
+dotnet_diagnostic.s1144.severity = none # Remove unused private member - reflection target
+dotnet_diagnostic.cs0414.severity = none # Field assigned but never used - reflection target
+dotnet_diagnostic.cs0628.severity = none # New protected member in sealed type - fixture surface
+dotnet_diagnostic.cs0109.severity = none # Member does not hide an accessible member ('new' not required)
+
+# Unused parameters on fixture / interface-implementing signatures
+dotnet_diagnostic.ide0060.severity = none # Remove unused parameter
+dotnet_diagnostic.s1172.severity = none # Remove unused method parameter
+
+# Member naming - names are reflection targets asserted on by tests
+dotnet_diagnostic.sa1300.severity = none # Element should begin with an uppercase letter
+dotnet_diagnostic.sa1306.severity = none # Field should begin with a lower-case letter
+
+# Empty marker / placeholder types and methods used as fixtures
+dotnet_diagnostic.s2094.severity = none # Remove empty class - empty fixture/marker types
+dotnet_diagnostic.s1186.severity = none # Add a body/comment to empty method - empty fixture methods

--- a/tests/Common.DataAnnotations.Tests/RequiredNotDefaultDateAttributeTests.cs
+++ b/tests/Common.DataAnnotations.Tests/RequiredNotDefaultDateAttributeTests.cs
@@ -14,9 +14,9 @@ public class RequiredNotDefaultDateAttributeTests
             new object?[] { default(DateOnly), false },
             new object?[] { "some-string", false },
             new object?[] { 123, false },
-            new object?[] { DateTime.Now, true },
-            new object?[] { DateTimeOffset.Now, true },
-            new object?[] { DateOnly.FromDateTime(DateTime.Now), true }
+            new object?[] { new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc), true },
+            new object?[] { new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero), true },
+            new object?[] { new DateOnly(2020, 1, 1), true }
         };
 
     [Theory]

--- a/tests/Common.DataAnnotations.Tests/RequiredNotDefaultDateAttributeTests.cs
+++ b/tests/Common.DataAnnotations.Tests/RequiredNotDefaultDateAttributeTests.cs
@@ -5,16 +5,19 @@ namespace Ploch.Common.DataAnnotations.Tests;
 
 public class RequiredNotDefaultDateAttributeTests
 {
-    public static IEnumerable<object?[]> Data => new List<object?[]>
-                                                 { new object?[] { null, false },
-                                                   new object?[] { default(DateTime), false },
-                                                   new object?[] { default(DateTimeOffset), false },
-                                                   new object?[] { default(DateOnly), false },
-                                                   new object?[] { "some-string", false },
-                                                   new object?[] { 123, false },
-                                                   new object?[] { DateTime.Now, true },
-                                                   new object?[] { DateTimeOffset.Now, true },
-                                                   new object?[] { DateOnly.FromDateTime(DateTime.Now), true } };
+    public static IEnumerable<object?[]> Data =>
+        new List<object?[]>
+        {
+            new object?[] { null, false },
+            new object?[] { default(DateTime), false },
+            new object?[] { default(DateTimeOffset), false },
+            new object?[] { default(DateOnly), false },
+            new object?[] { "some-string", false },
+            new object?[] { 123, false },
+            new object?[] { DateTime.Now, true },
+            new object?[] { DateTimeOffset.Now, true },
+            new object?[] { DateOnly.FromDateTime(DateTime.Now), true }
+        };
 
     [Theory]
     [MemberData(nameof(Data))]

--- a/tests/Common.DependencyInjection.Tests/ScopedServiceTests.cs
+++ b/tests/Common.DependencyInjection.Tests/ScopedServiceTests.cs
@@ -53,7 +53,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task DisposeAsync_should_dispose_scope()
+    public async Task DisposeAsync_should_dispose_scope() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
     {
         var services = new ServiceCollection();
         services.AddScoped<ITestService, TestService>();
@@ -68,7 +68,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task DisposeAsync_should_be_idempotent()
+    public async Task DisposeAsync_should_be_idempotent() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
     {
         var services = new ServiceCollection();
         services.AddScoped<ITestService, TestService>();
@@ -84,7 +84,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task DisposeAsync_after_Dispose_should_not_throw()
+    public async Task DisposeAsync_after_Dispose_should_not_throw() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
     {
         var services = new ServiceCollection();
         services.AddScoped<ITestService, TestService>();
@@ -100,7 +100,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task Dispose_after_DisposeAsync_should_not_throw()
+    public async Task Dispose_after_DisposeAsync_should_not_throw() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
     {
         var services = new ServiceCollection();
         services.AddScoped<ITestService, TestService>();
@@ -116,7 +116,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task GenericScopedService_should_dispose_scope_async()
+    public async Task GenericScopedService_should_dispose_scope_async() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
     {
         var services = new ServiceCollection();
         services.AddScoped<ITestService, TestService>();
@@ -158,7 +158,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task DisposeAsync_should_fall_back_to_sync_dispose_when_scope_is_not_async_disposable()
+    public async Task DisposeAsync_should_fall_back_to_sync_dispose_when_scope_is_not_async_disposable() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
     {
         // Create a mock scope that implements IDisposable but NOT IAsyncDisposable
         var mockScope = new Mock<IServiceScope>();

--- a/tests/Common.DependencyInjection.Tests/ScopedServiceTests.cs
+++ b/tests/Common.DependencyInjection.Tests/ScopedServiceTests.cs
@@ -53,7 +53,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task DisposeAsync_should_dispose_scope() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
+    public async Task DisposeAsync_should_dispose_scope()
     {
         var services = new ServiceCollection();
         services.AddScoped<ITestService, TestService>();
@@ -68,7 +68,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task DisposeAsync_should_be_idempotent() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
+    public async Task DisposeAsync_should_be_idempotent()
     {
         var services = new ServiceCollection();
         services.AddScoped<ITestService, TestService>();
@@ -84,7 +84,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task DisposeAsync_after_Dispose_should_not_throw() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
+    public async Task DisposeAsync_after_Dispose_should_not_throw()
     {
         var services = new ServiceCollection();
         services.AddScoped<ITestService, TestService>();
@@ -100,7 +100,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task Dispose_after_DisposeAsync_should_not_throw() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
+    public async Task Dispose_after_DisposeAsync_should_not_throw()
     {
         var services = new ServiceCollection();
         services.AddScoped<ITestService, TestService>();
@@ -116,7 +116,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task GenericScopedService_should_dispose_scope_async() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
+    public async Task GenericScopedService_should_dispose_scope_async()
     {
         var services = new ServiceCollection();
         services.AddScoped<ITestService, TestService>();
@@ -158,7 +158,7 @@ public class ScopedServiceTests
     }
 
     [Fact]
-    public async Task DisposeAsync_should_fall_back_to_sync_dispose_when_scope_is_not_async_disposable() // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
+    public async Task DisposeAsync_should_fall_back_to_sync_dispose_when_scope_is_not_async_disposable()
     {
         // Create a mock scope that implements IDisposable but NOT IAsyncDisposable
         var mockScope = new Mock<IServiceScope>();

--- a/tests/Common.DependencyInjection.Tests/ScopedServiceTests.cs
+++ b/tests/Common.DependencyInjection.Tests/ScopedServiceTests.cs
@@ -48,7 +48,7 @@ public class ScopedServiceTests
         scopedService.Dispose();
 
         // Second dispose should not throw
-        var act = () => scopedService.Dispose();
+        var act = scopedService.Dispose;
         act.Should().NotThrow();
     }
 
@@ -111,7 +111,7 @@ public class ScopedServiceTests
         await scopedService.DisposeAsync();
 
         // Dispose after DisposeAsync should be safe (idempotent)
-        var act = () => scopedService.Dispose();
+        var act = scopedService.Dispose;
         act.Should().NotThrow();
     }
 

--- a/tests/Common.DependencyInjection.Tests/ServicesBundleTests.cs
+++ b/tests/Common.DependencyInjection.Tests/ServicesBundleTests.cs
@@ -46,7 +46,7 @@ public class ServicesBundleTests
         protected override IEnumerable<IServicesBundle>? Dependencies => [ new ServiceBundleB(), new ServiceBundleC() ];
     }
 
-    public class ServiceBundleB : TestServicesBundle;
+    public class ServiceBundleB : TestServicesBundle { }
 
-    public class ServiceBundleC : TestServicesBundle;
+    public class ServiceBundleC : TestServicesBundle { }
 }

--- a/tests/Common.Net9.Tests/AppDomainTypesLoaderTests.cs
+++ b/tests/Common.Net9.Tests/AppDomainTypesLoaderTests.cs
@@ -75,7 +75,7 @@ public class AppDomainTypesLoaderTests
         var loader = new AppDomainTypesLoader(new TypeLoadingConfiguration());
 
         // Act
-        var act = () => loader.ProcessAllAssemblies();
+        var act = loader.ProcessAllAssemblies;
 
         // Assert
         act.Should().NotThrow();

--- a/tests/Common.Net9.Tests/GlobalUsings.cs
+++ b/tests/Common.Net9.Tests/GlobalUsings.cs
@@ -1,2 +1,2 @@
-global using Xunit;
 global using FluentAssertions;
+global using Xunit;

--- a/tests/Common.Serialization.NewtonsoftJson.Tests/GlobalUsings.cs
+++ b/tests/Common.Serialization.NewtonsoftJson.Tests/GlobalUsings.cs
@@ -1,2 +1,2 @@
-global using Xunit;
 global using FluentAssertions;
+global using Xunit;

--- a/tests/Common.Serialization.Tests/GlobalUsings.cs
+++ b/tests/Common.Serialization.Tests/GlobalUsings.cs
@@ -1,2 +1,2 @@
-global using Xunit;
 global using FluentAssertions;
+global using Xunit;

--- a/tests/Common.Tests/ArgumentChecking/GuardNet7Tests.cs
+++ b/tests/Common.Tests/ArgumentChecking/GuardNet7Tests.cs
@@ -329,7 +329,7 @@ public class GuardNet7Tests
     public void NotNullOrDefault_should_throw_if_argument_is_default_value()
     {
         // Arrange
-        int argXyz = default;
+        var argXyz = default(int);
 
         // Act
         Action act = () => argXyz.NotNullOrDefault();
@@ -343,7 +343,7 @@ public class GuardNet7Tests
     {
         // Arrange
         string? nullArg = null;
-        int defaultArg = default;
+        var defaultArg = default(int);
 
         // Act
         Action nullAct = () => nullArg.NotNullOrDefault();

--- a/tests/Common.Tests/ArgumentChecking/GuardTests.cs
+++ b/tests/Common.Tests/ArgumentChecking/GuardTests.cs
@@ -58,7 +58,6 @@ public class GuardTests
     // Net7+ message-format semantics (single positional arg = format template) are tested in GuardNet7Tests.cs.
     // The netstandard2.0 partial inverts the parameter order (memberName first, message second), so the
     // single-positional-arg call has different semantics on that binary. See issue #207.
-
     [Fact]
     public void NotNullOrEmpty_should_return_enumerable_when_not_null_or_empty()
     {

--- a/tests/Common.Tests/Collections/CollectionExtensionsTests.cs
+++ b/tests/Common.Tests/Collections/CollectionExtensionsTests.cs
@@ -23,8 +23,8 @@ public class CollectionExtensionsTests
         var act = static () =>
                   {
                       List<KeyValuePair<string, string>>? list = null;
-#pragma warning disable CS8604 Possible null reference argument. - this is the point of the test
-#pragma warning disable CS8620 Argument cannot be used for parameter due to differences in the nullability of reference types. - this is the point of the test
+#pragma warning disable CS8604 // Possible null reference argument. - this is the point of the test
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types. - this is the point of the test
                       list.Add("a", "b");
 #pragma warning restore CS8620
 #pragma warning restore CS8604
@@ -56,7 +56,7 @@ public class CollectionExtensionsTests
 
         var collection = target.AddMany(items);
         target.Should().HaveCount(4);
-        target.Should().Contain(["itme1", "item2"], "item3", "item4");
+        target.Should().Contain(["itme1", "item2", "item3", "item4"]);
 
         collection.Should().BeSameAs(target);
     }
@@ -160,7 +160,7 @@ public class CollectionExtensionsTests
                   };
 
         // Assert
-        act.Should().Throw<ArgumentNullException>().WithParameterName("collection");
+        act.Should().Throw<ArgumentNullException>().WithParameterName(nameof(collection));
     }
 
     [Fact]

--- a/tests/Common.Tests/Collections/DictionaryExtensionsTests.cs
+++ b/tests/Common.Tests/Collections/DictionaryExtensionsTests.cs
@@ -32,7 +32,7 @@ public class DictionaryExtensionsTests
         // Act & Assert
         var action = () => dictionary!.AddMany(entries);
 
-        action.Should().Throw<ArgumentNullException>().WithParameterName("dictionary");
+        action.Should().Throw<ArgumentNullException>().WithParameterName(nameof(dictionary));
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class DictionaryExtensionsTests
         // Act & Assert
         var action = () => dictionary.AddMany(items!);
 
-        action.Should().Throw<ArgumentNullException>().WithParameterName("items");
+        action.Should().Throw<ArgumentNullException>().WithParameterName(nameof(items));
     }
 
     [Fact]

--- a/tests/Common.Tests/Collections/EnumerableQueriesTests.cs
+++ b/tests/Common.Tests/Collections/EnumerableQueriesTests.cs
@@ -23,11 +23,11 @@ public class EnumerableQueriesTests
     [Fact]
     public void GetWithEmptyProperty_should_return_items_with_empty_string_properties()
     {
-        var items = new[] { new TestItem("1", string.Empty), new TestItem("2", "not empty"), new TestItem("3", "") };
+        var items = new[] { new TestItem("1", string.Empty), new TestItem("2", "not empty"), new TestItem("3", string.Empty) };
         var result = items.GetWithEmptyProperty(x => x.Value2);
         result.Should().HaveCount(2);
         result.Should().Contain(ti => ti.Value1 == "1" && ti.Value2 == string.Empty);
-        result.Should().Contain(ti => ti.Value1 == "3" && ti.Value2 == "");
+        result.Should().Contain(ti => ti.Value1 == "3" && ti.Value2 == string.Empty);
     }
 
     private record TestItem(string? Value1, string? Value2);

--- a/tests/Common.Tests/Collections/KeyValuePairExtensionsTests.cs
+++ b/tests/Common.Tests/Collections/KeyValuePairExtensionsTests.cs
@@ -8,7 +8,7 @@ public class KeyValuePairExtensionsTests
     {
         dictionary.Should().NotBeEmpty();
 
-        foreach (var (key, value) in dictionary)
+        foreach (var (key, _) in dictionary)
         {
             key.Should().NotBeNull();
         }

--- a/tests/Common.Tests/DateTimeExtensionsTests.cs
+++ b/tests/Common.Tests/DateTimeExtensionsTests.cs
@@ -20,16 +20,16 @@ public class DateTimeExtensionsTests
   public void ToDateTime_should_convert_any_number_to_DateTime()
   {
     long longSeconds = 0;
-    longSeconds.ToDateTime().Should().Be(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    longSeconds.ToDateTime().Should().Be(DateTime.UnixEpoch);
 
     var intSeconds = 0;
-    intSeconds.ToDateTime().Should().Be(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    intSeconds.ToDateTime().Should().Be(DateTime.UnixEpoch);
 
     float floatSeconds = 0;
-    floatSeconds.ToDateTime().Should().Be(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    floatSeconds.ToDateTime().Should().Be(DateTime.UnixEpoch);
 
     sbyte sbyteSeconds = 0;
-    sbyteSeconds.ToDateTime().Should().Be(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    sbyteSeconds.ToDateTime().Should().Be(DateTime.UnixEpoch);
 
     sbyteSeconds.ToDateTime().ToEpochSeconds().Should().Be(0);
   }

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -19,21 +19,6 @@ public class ProcessExtensionsTests
         enabledProcessors = process.GetEnabledProcessors();
         enabledProcessors.Should().HaveCount(1);
         enabledProcessors.Should().Contain(Environment.ProcessorCount - 1);
-
-        // Environment.ProcessorCount
-        // process.Aff
-
-        // // Arrange
-        // var processMock = new Mock<Process>();
-        // var processorNumber = 2;
-        // var expectedMask = 1L << processorNumber;
-        // processMock.SetupProperty(p => p.ProcessorAffinity);
-        //
-        // // Act
-        // processMock.Object.SetSingleProcessorAffinity(processorNumber);
-        //
-        // // Assert
-        // processMock.Object.ProcessorAffinity.Should().Be((IntPtr)expectedMask);
     }
 
     [Theory]

--- a/tests/Common.Tests/ExpressionExtensionsTests.cs
+++ b/tests/Common.Tests/ExpressionExtensionsTests.cs
@@ -98,7 +98,7 @@ public class ExpressionExtensionsTests
     public void GetMemberName_Action_should_throw_for_unsupported_expression()
     {
         // BinaryExpression (addition) is not a MemberExpression or MethodCallExpression
-        Expression<Action> expression = Expression.Lambda<Action>(
+        var expression = Expression.Lambda<Action>(
             Expression.Block(Expression.Constant(0)),
             Array.Empty<ParameterExpression>());
 
@@ -111,7 +111,7 @@ public class ExpressionExtensionsTests
     public void GetMemberName_Func_should_throw_for_unsupported_expression()
     {
         // Constant expression is not a MemberExpression or MethodCallExpression
-        Expression<Func<int>> expression = Expression.Lambda<Func<int>>(
+        var expression = Expression.Lambda<Func<int>>(
             Expression.Constant(42),
             Array.Empty<ParameterExpression>());
 
@@ -125,7 +125,7 @@ public class ExpressionExtensionsTests
     {
         // Constant expression is not a MemberExpression, MethodCallExpression, or UnaryExpression
         var param = Expression.Parameter(typeof(TestType), "x");
-        Expression<Func<TestType, int>> expression = Expression.Lambda<Func<TestType, int>>(
+        var expression = Expression.Lambda<Func<TestType, int>>(
             Expression.Constant(42),
             param);
 

--- a/tests/Common.Tests/Reflection/AssemblyExtensionsTests.cs
+++ b/tests/Common.Tests/Reflection/AssemblyExtensionsTests.cs
@@ -308,7 +308,6 @@ public class AssemblyExtensionsTests
 #pragma warning disable S2326
 
 // ReSharper disable once UnusedTypeParameter
-
 #pragma warning restore SA1201
 #pragma warning restore S2094
 #pragma warning restore RCS1102

--- a/tests/Common.Tests/Reflection/MemberInfoExtensionsTests.cs
+++ b/tests/Common.Tests/Reflection/MemberInfoExtensionsTests.cs
@@ -32,7 +32,7 @@ public class MemberInfoExtensionsTests
         var testObject = new ClassWithFieldsAndProperties();
 
         // Get a MethodInfo which is neither FieldInfo nor PropertyInfo
-        MemberInfo? member = testObject.GetType().GetMethod("ToString");
+        MemberInfo? member = testObject.GetType().GetMethod(nameof(ToString));
 
         // Act & Assert
         member.GetValue(testObject).Should().BeNull();

--- a/tests/Common.Tests/Reflection/ObjectHashCodeBuilderTests.cs
+++ b/tests/Common.Tests/Reflection/ObjectHashCodeBuilderTests.cs
@@ -13,7 +13,6 @@ public class ObjectHashCodeBuilderTests
     [Fact]
     public void GetHashCode_should_return_type_hash_code_for_object_with_no_properties()
     {
-        var sut = new TestTypes.NoPropertiesObject();
         var obj = new TestTypes.NoPropertiesObject();
         ObjectHashCodeBuilder.GetHashCode(obj).Should().Be(typeof(TestTypes.NoPropertiesObject).GetHashCode());
     }

--- a/tests/Common.Tests/Reflection/ObjectReflectionExtensionsTests.cs
+++ b/tests/Common.Tests/Reflection/ObjectReflectionExtensionsTests.cs
@@ -213,7 +213,7 @@ public class ObjectReflectionExtensionsTests
         publicFields.Should().HaveCount(1);
     }
 
-    [Fact(Skip = "TODO: Needs fixing")] //TODO: Fix this test
+    [Fact(Skip = "TODO: Needs fixing")] // TODO: Fix this test
     public void GetFieldValues_should_throw_appropriate_exception_when_invalid_binding_flags_are_provided()
     {
         // Arrange
@@ -366,7 +366,7 @@ public class ObjectReflectionExtensionsTests
     [Fact]
     public void GetMemberValues_should_correctly_return_indexed_properties()
     {
-        //TODO
+        // TODO
         // Arrange
         var testObject = new ClassWithIndexedProperty2();
         testObject["key1"] = "value1";
@@ -481,8 +481,8 @@ public class ObjectReflectionExtensionsTests
     {
         private static readonly string StaticField = "static field value";
 
-        public static readonly string StaticStrField1 = nameof(StaticStrField1) + "Value";
-        public static readonly string StaticStrField2 = nameof(StaticStrField2) + "Value";
+        public static readonly string StaticStrField1 = nameof(StaticStrField1) + "FieldValue";
+        public static readonly string StaticStrField2 = nameof(StaticStrField2) + "FieldValue";
         public static readonly int StaticIntField1 = 1;
         public static readonly int StaticIntField2 = 2;
         public readonly string PublicField = "instance field value";

--- a/tests/Common.Tests/Reflection/PropertyHelpersGetPropertyValueTests.cs
+++ b/tests/Common.Tests/Reflection/PropertyHelpersGetPropertyValueTests.cs
@@ -232,7 +232,6 @@ public class PropertyHelpersGetPropertyValueTests
         var propertyInfo = typeof(ClassWithIndexer).GetProperty(PropertyHelpers.IndexerPropertyName);
 
         // Act
-
         Action action = () => testObject.GetPropertyValue(propertyInfo!, ["a"]);
 
         // Assert
@@ -283,9 +282,7 @@ public class PropertyHelpersGetPropertyValueTests
     public void GetPropertyValue_should_handle_properties_from_structs(int testValue)
     {
         // Arrange
-        var testStruct = new TestStruct(testValue,
-                                        new()
-                                            { IntProperty = testValue, StringProperty = Guid.NewGuid().ToString() });
+        var testStruct = new TestStruct(testValue, new() { IntProperty = testValue, StringProperty = Guid.NewGuid().ToString() });
 
         // Act
         var result = testStruct.GetPropertyValue(x => x.StructProperty);

--- a/tests/Common.Tests/Reflection/PropertyHelpersTests.cs
+++ b/tests/Common.Tests/Reflection/PropertyHelpersTests.cs
@@ -335,7 +335,7 @@ public class PropertyHelpersTests
 
         // Assert
         result.Should().Contain(item => item.Item1 == nameof(TestClassWithNullableProperties.StringProp) && (string)item.Item2! == StringPropValue);
-        result.Should().Contain(item => item.Item1 == nameof(TestClassWithNullableProperties.StringProp2) && item.Item2 == StringProp2Value);
+        result.Should().Contain(item => item.Item1 == nameof(TestClassWithNullableProperties.StringProp2) && (string)item.Item2! == StringProp2Value);
         result.Should().Contain(item => item.Item1 == nameof(TestClassWithNullableProperties.NullableIntProp) && (int?)item.Item2 == nullableIntPropValue);
         result.Should().Contain(item => item.Item1 == nameof(TestClassWithNullableProperties.NullableIntProp2) && (int?)item.Item2 == nullableIntProp2Value);
     }
@@ -445,7 +445,7 @@ public class PropertyHelpersTests
 
         result.Should().Contain(item => item.Item1 == "Id" && (int)item.Item2! == 42);
         result.Should().Contain(item => item.Item1 == "Name" && (string)item.Item2! == "Anonymous");
-        result.Should().Contain(item => item.Item1 == "IsActive" && (bool)item.Item2! == true);
+        result.Should().Contain(item => item.Item1 == "IsActive" && (bool)item.Item2!);
         result.Should().Contain(item => item.Item1 == "CreatedDate" && item.Item2 is DateTime);
     }
 

--- a/tests/Common.Tests/Reflection/PropertyHelpersTests.cs
+++ b/tests/Common.Tests/Reflection/PropertyHelpersTests.cs
@@ -335,7 +335,7 @@ public class PropertyHelpersTests
 
         // Assert
         result.Should().Contain(item => item.Item1 == nameof(TestClassWithNullableProperties.StringProp) && (string)item.Item2! == StringPropValue);
-        result.Should().Contain(item => item.Item1 == nameof(TestClassWithNullableProperties.StringProp2) && (string)item.Item2! == StringProp2Value);
+        result.Should().Contain(item => item.Item1 == nameof(TestClassWithNullableProperties.StringProp2) && (string?)item.Item2 == StringProp2Value);
         result.Should().Contain(item => item.Item1 == nameof(TestClassWithNullableProperties.NullableIntProp) && (int?)item.Item2 == nullableIntPropValue);
         result.Should().Contain(item => item.Item1 == nameof(TestClassWithNullableProperties.NullableIntProp2) && (int?)item.Item2 == nullableIntProp2Value);
     }

--- a/tests/Common.Tests/Reflection/TypeLoaderTests.cs
+++ b/tests/Common.Tests/Reflection/TypeLoaderTests.cs
@@ -86,14 +86,4 @@ public class TypeLoaderTests
         // Assert
         act.Should().Throw<ArgumentNullException>().WithParameterName("configurator");
     }
-
-    [Fact]
-    public void Constructor_throws_ArgumentNullException_when_configuration_is_null()
-    {
-        // Act
-        Action act = () => TypeLoader.Configure(null!);
-
-        // Assert
-        act.Should().Throw<ArgumentNullException>().WithParameterName("configurator");
-    }
 }

--- a/tests/Common.Tests/Results/ErrorInfoTests.cs
+++ b/tests/Common.Tests/Results/ErrorInfoTests.cs
@@ -77,7 +77,7 @@ public class ErrorInfoTests
         var act = () => ErrorInfo.Create(exception!);
 
         // Assert
-        act.Should().Throw<ArgumentNullException>().WithParameterName("exception");
+        act.Should().Throw<ArgumentNullException>().WithParameterName(nameof(exception));
     }
 
     [Fact]

--- a/tests/Common.Tests/StringExtensionsTests.cs
+++ b/tests/Common.Tests/StringExtensionsTests.cs
@@ -171,7 +171,7 @@ public class StringExtensionsTests
                            .Be("My very long replacement awesome string...");
         "test string where result should be the same".ReplaceStart("est string", "not important").Should().Be("test string where result should be the same");
 
-        "".ReplaceStart("", "My awesome", StringComparison.OrdinalIgnoreCase).Should().Be("My awesome");
+        string.Empty.ReplaceStart(string.Empty, "My awesome", StringComparison.OrdinalIgnoreCase).Should().Be("My awesome");
     }
 
     [Theory]

--- a/tests/Common.Tests/StringParsingExtensionsTests.cs
+++ b/tests/Common.Tests/StringParsingExtensionsTests.cs
@@ -7,7 +7,7 @@ public class StringParsingExtensionsTests
     {
         string nullString = null;
         nullString.ParseToBool().Should().BeNull();
-        "".ParseToBool().Should().BeNull();
+        string.Empty.ParseToBool().Should().BeNull();
         "   ".ParseToBool().Should().BeNull();
     }
 
@@ -48,7 +48,7 @@ public class StringParsingExtensionsTests
     {
         string nullString = null;
         nullString.ParseToInt32().Should().BeNull();
-        "".ParseToInt32().Should().BeNull();
+        string.Empty.ParseToInt32().Should().BeNull();
         "   ".ParseToInt32().Should().BeNull();
     }
 
@@ -76,7 +76,7 @@ public class StringParsingExtensionsTests
     {
         string nullString = null;
         nullString.ParseToInt64().Should().BeNull();
-        "".ParseToInt64().Should().BeNull();
+        string.Empty.ParseToInt64().Should().BeNull();
         "   ".ParseToInt64().Should().BeNull();
     }
 

--- a/tests/TestAssemblies/Common.Tests.TestAssembly1/TestAssembly1Info.cs
+++ b/tests/TestAssemblies/Common.Tests.TestAssembly1/TestAssembly1Info.cs
@@ -7,15 +7,24 @@ public static class TestAssembly1Info
     public static Assembly Assembly => typeof(TestAssembly1Info).Assembly;
 
     public static IDictionary<Type, IEnumerable<Type>> Inheritors => new Dictionary<Type, IEnumerable<Type>>
-                                                                     {
-                                                                     { typeof(BaseClass),
-                                                                       [ typeof(DerivedClass), typeof(BaseClassImplementation1), typeof(DerivedClass) ] },
-                                                                     { typeof(IBaseInterface),
-                                                                       [ typeof(BaseClass),
-                                                                         typeof(BaseClassImplementation1),
-                                                                         typeof(DerivedClass),
-                                                                         typeof(Interface1Implementation1),
-                                                                         typeof(Interface1Implementation2) ] },
-                                                                     { typeof(IGenericInterface<>),
-                                                                       [ typeof(TestGenericClass3<>), typeof(TestClass4GenericClass3OfInt) ] } };
+    {
+        {
+            typeof(BaseClass),
+            [typeof(DerivedClass), typeof(BaseClassImplementation1), typeof(DerivedClass)]
+        },
+        {
+            typeof(IBaseInterface),
+            [
+                typeof(BaseClass),
+                typeof(BaseClassImplementation1),
+                typeof(DerivedClass),
+                typeof(Interface1Implementation1),
+                typeof(Interface1Implementation2)
+            ]
+        },
+        {
+            typeof(IGenericInterface<>),
+            [typeof(TestGenericClass3<>), typeof(TestClass4GenericClass3OfInt)]
+        }
+    };
 }

--- a/tests/TestAssemblies/Common.Tests.TestAssembly2/Assembly2Type1.cs
+++ b/tests/TestAssemblies/Common.Tests.TestAssembly2/Assembly2Type1.cs
@@ -1,3 +1,4 @@
 namespace Ploch.Common.Tests.TestAssembly2;
 
-public class Assembly2Type1;
+public class Assembly2Type1
+{ }

--- a/tests/TestAssemblies/Common.Tests.TestAssembly2/Assembly2Type2.cs
+++ b/tests/TestAssemblies/Common.Tests.TestAssembly2/Assembly2Type2.cs
@@ -1,3 +1,4 @@
 namespace Ploch.Common.Tests.TestAssembly2;
 
-public class Assembly2Type2;
+public class Assembly2Type2
+{ }

--- a/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/Attribute2Attribute.cs
+++ b/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/Attribute2Attribute.cs
@@ -8,5 +8,5 @@ public class Attribute2Attribute(string name) : Attribute
 
     public int PropInt { get; set; }
 
-    public string Test() => "Test";
+    public string Test() => nameof(Test);
 }

--- a/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/Attribute2Attribute.cs
+++ b/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/Attribute2Attribute.cs
@@ -2,6 +2,7 @@
 
 namespace Ploch.Common.Tests.TestTypes.TestingTypes;
 
+[AttributeUsage(AttributeTargets.Class)]
 public class Attribute2Attribute(string name) : Attribute
 {
     public string Name { get; } = name;

--- a/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/ByteEnum.cs
+++ b/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/ByteEnum.cs
@@ -2,13 +2,12 @@
 
 namespace Ploch.Common.Tests.TestTypes.TestingTypes;
 
-[SuppressMessage("ReSharper", "InconsistentNaming")]
-[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-[SuppressMessage("ReSharper", "UnusedMember.Global")]
-[SuppressMessage("ReSharper", "UnusedMember.Global")]
-[SuppressMessage("ReSharper", "NotAccessedField.Local")]
-[SuppressMessage("ReSharper", "PropertyCanBeMadeInitOnly.Global")]
-[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+[SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Test fixture - intentional shape for reflection/serialization tests")]
+[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global", Justification = "Test fixture - intentional shape for reflection/serialization tests")]
+[SuppressMessage("ReSharper", "UnusedMember.Global", Justification = "Test fixture - intentional shape for reflection/serialization tests")]
+[SuppressMessage("ReSharper", "NotAccessedField.Local", Justification = "Test fixture - intentional shape for reflection/serialization tests")]
+[SuppressMessage("ReSharper", "PropertyCanBeMadeInitOnly.Global", Justification = "Test fixture - intentional shape for reflection/serialization tests")]
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Test fixture - intentional shape for reflection/serialization tests")]
 public enum ByteEnum : byte
 {
     Value1 = 1,

--- a/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/ByteEnum.cs
+++ b/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/ByteEnum.cs
@@ -8,7 +8,7 @@ namespace Ploch.Common.Tests.TestTypes.TestingTypes;
 [SuppressMessage("ReSharper", "NotAccessedField.Local", Justification = "Test fixture - intentional shape for reflection/serialization tests")]
 [SuppressMessage("ReSharper", "PropertyCanBeMadeInitOnly.Global", Justification = "Test fixture - intentional shape for reflection/serialization tests")]
 [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Test fixture - intentional shape for reflection/serialization tests")]
-public enum ByteEnum : byte
+public enum ByteEnum : byte // skipcq: CS-P1021 - byte backing type is the subject under test
 {
     Value1 = 1,
     Value2 = 2,

--- a/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/EmptyClass.cs
+++ b/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/EmptyClass.cs
@@ -1,3 +1,4 @@
 ﻿namespace Ploch.Common.Tests.TestTypes.TestingTypes;
 
-public class EmptyClass;
+public class EmptyClass
+{ }

--- a/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/TestTypeWithMixedSettersAndGetter.cs
+++ b/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/TestTypeWithMixedSettersAndGetter.cs
@@ -9,7 +9,7 @@ public class TestTypeWithMixedSettersAndGetter
     public string? _stringPropNoGetter;
 
 #pragma warning disable 649 //  [CS0649] Field 'TestTypes.TestTypeWithMixedSettersAndGetter._stringPropNoSetter' is never assigned to, and will always have its default value null
-    [SuppressMessage("ReSharper", "UnassignedField.Global")]
+    [SuppressMessage("ReSharper", "UnassignedField.Global", Justification = "Test fixture - intentional shape for reflection/serialization tests")]
     public string? _stringPropNoSetter;
 #pragma warning restore 649
 

--- a/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/TypeHierarchies/TypeHierarchies.cs
+++ b/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/TypeHierarchies/TypeHierarchies.cs
@@ -36,20 +36,20 @@ public static class TypeHierarchies
         public class ConcreteClass_IHierarchiesTestInterface : IHierarchiesTestInterface
         { }
 
-        public abstract class AbstractClass_IHierarchiesTestInterface : IHierarchiesTestInterface
+        public abstract class AbstractClass_IHierarchiesTestInterface : IHierarchiesTestInterface // skipcq: CS-R1078 - intentional abstract reflection-test fixture
         { }
     }
 
     public static class HierarchyThree
     {
         // Test classes for abstract class inheritance
-        public abstract class AbstractBaseClass
+        public abstract class AbstractBaseClass // skipcq: CS-R1078 - intentional abstract reflection-test fixture
         { }
 
         public class ConcreteChildClass : AbstractBaseClass
         { }
 
-        public abstract class AbstractChildClass : AbstractBaseClass
+        public abstract class AbstractChildClass : AbstractBaseClass // skipcq: CS-R1078 - intentional abstract reflection-test fixture
         { }
     }
 
@@ -87,7 +87,7 @@ public static class TypeHierarchies
             public class NestedImplementor : INestedTypeInterface
             { }
 
-            public abstract class AbstractNestedImplementor : INestedTypeInterface
+            public abstract class AbstractNestedImplementor : INestedTypeInterface // skipcq: CS-R1078 - intentional abstract reflection-test fixture
             { }
         }
     }

--- a/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/TypeHierarchies/TypeHierarchies.cs
+++ b/tests/TestAssemblies/Common.Tests.TestTypes/TestingTypes/TypeHierarchies/TypeHierarchies.cs
@@ -3,11 +3,10 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 // ReSharper disable InconsistentNaming
-
 namespace Ploch.Common.Tests.Reflection;
 
 #pragma warning disable CS8603
-[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Test fixture - intentional shape for reflection/serialization tests")]
 public static class TypeHierarchies
 {
     public static class HierarchyOne

--- a/tests/TestingSupport.Tests/Moq/FluentVerifierTests.cs
+++ b/tests/TestingSupport.Tests/Moq/FluentVerifierTests.cs
@@ -9,7 +9,7 @@ namespace Ploch.TestingSupport.Tests.Moq;
 public class FluentVerifierTests
 {
   [Theory, AutoMockData]
-  public async Task VerifyFluentAssertion_should_match_verification_using_fluent_assertions(Mock<IMyService1> myServiceMock,
+  public async Task VerifyFluentAssertion_should_match_verification_using_fluent_assertions(Mock<IMyService1> myServiceMock, // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
                                                                                             TestRecord1 testRecord1A,
                                                                                             TestRecord2 testRecord2A,
                                                                                             TestRecord1 testRecord1B,

--- a/tests/TestingSupport.Tests/Moq/FluentVerifierTests.cs
+++ b/tests/TestingSupport.Tests/Moq/FluentVerifierTests.cs
@@ -17,11 +17,7 @@ public class FluentVerifierTests
   {
     myServiceMock.Object.DoSomething(testRecord1A, testRecord2A);
 
-    FluentVerifier.VerifyFluentAssertion(() =>
-                                         {
-                                           var x = 1;
-                                           var y = 2;
-                                         });
+    FluentVerifier.VerifyFluentAssertion(() => { });
     myServiceMock.Verify(x => x.DoSomething(It.Is<TestRecord1>(rec1 => Verify(rec1, testRecord1A)),
                                             It.Is<TestRecord2>(rec2 => Verify(rec2, testRecord2A))));
   }

--- a/tests/TestingSupport.Tests/Moq/FluentVerifierTests.cs
+++ b/tests/TestingSupport.Tests/Moq/FluentVerifierTests.cs
@@ -9,7 +9,7 @@ namespace Ploch.TestingSupport.Tests.Moq;
 public class FluentVerifierTests
 {
   [Theory, AutoMockData]
-  public async Task VerifyFluentAssertion_should_match_verification_using_fluent_assertions(Mock<IMyService1> myServiceMock, // skipcq: CS-R1073 - repo test-naming convention (_should_); Async suffix intentionally omitted
+  public void VerifyFluentAssertion_should_match_verification_using_fluent_assertions(Mock<IMyService1> myServiceMock,
                                                                                             TestRecord1 testRecord1A,
                                                                                             TestRecord2 testRecord2A,
                                                                                             TestRecord1 testRecord1B,

--- a/tests/TestingSupport.Tests/TestData/JsonFileDataAttributeTests.cs
+++ b/tests/TestingSupport.Tests/TestData/JsonFileDataAttributeTests.cs
@@ -7,7 +7,7 @@ namespace Ploch.TestingSupport.Tests;
 #pragma warning disable xUnit1003 // Theory must have test data - doesn't recognize custom data attributes
 public class JsonFileDataAttributeTests
 {
-  [Theory, JsonFileData("TestData/TestData.json", "Student")]
+  [Theory, JsonFileData("TestData/TestData.json", nameof(Student))]
   public void EnrollStudent_Success(Student student, int id)
   {
     if (id == 0)

--- a/tests/TestingSupport.XUnit3.Tests/Moq/FluentVerifierTests.cs
+++ b/tests/TestingSupport.XUnit3.Tests/Moq/FluentVerifierTests.cs
@@ -10,7 +10,7 @@ public class FluentVerifierTests
 {
     [Theory]
     [AutoMockData]
-    public async Task VerifyFluentAssertion_should_match_verification_using_fluent_assertions(Mock<IMyService1> myServiceMock,
+    public void VerifyFluentAssertion_should_match_verification_using_fluent_assertions(Mock<IMyService1> myServiceMock,
                                                                                               TestRecord1 testRecord1A,
                                                                                               TestRecord2 testRecord2A,
                                                                                               TestRecord1 testRecord1B,
@@ -25,7 +25,7 @@ public class FluentVerifierTests
 
     [Theory]
     [AutoMockData]
-    public async Task VerifyFluentAssertionAsync_should_match_verification_using_fluent_assertions(Mock<IMyService1> myServiceMock,
+    public async Task VerifyFluentAssertionAsync_should_match_verification_using_fluent_assertions(Mock<IMyService1> myServiceMock, // skipcq: CS-R1073 - repo test-naming convention (_should_); method awaits so async is required
                                                                                                    TestRecord1 testRecord1A,
                                                                                                    TestRecord2 testRecord2A,
                                                                                                    TestRecord1 testRecord1B,

--- a/tests/TestingSupport.XUnit3.Tests/Moq/FluentVerifierTests.cs
+++ b/tests/TestingSupport.XUnit3.Tests/Moq/FluentVerifierTests.cs
@@ -25,7 +25,7 @@ public class FluentVerifierTests
 
     [Theory]
     [AutoMockData]
-    public async Task VerifyFluentAssertionAsync_should_match_verification_using_fluent_assertions(Mock<IMyService1> myServiceMock, // skipcq: CS-R1073 - repo test-naming convention (_should_); method awaits so async is required
+    public async Task VerifyFluentAssertionAsync_should_match_verification_using_fluent_assertions(Mock<IMyService1> myServiceMock,
                                                                                                    TestRecord1 testRecord1A,
                                                                                                    TestRecord2 testRecord2A,
                                                                                                    TestRecord1 testRecord1B,

--- a/tests/TestingSupport.XUnit3.Tests/Moq/FluentVerifierTests.cs
+++ b/tests/TestingSupport.XUnit3.Tests/Moq/FluentVerifierTests.cs
@@ -18,11 +18,7 @@ public class FluentVerifierTests
     {
         myServiceMock.Object.DoSomething(testRecord1A, testRecord2A);
 
-        FluentVerifier.VerifyFluentAssertion(() =>
-                                             {
-                                                 var x = 1;
-                                                 var y = 2;
-                                             });
+        FluentVerifier.VerifyFluentAssertion(() => { });
         myServiceMock.Verify(x => x.DoSomething(It.Is<TestRecord1>(rec1 => Verify(rec1, testRecord1A)),
                                                 It.Is<TestRecord2>(rec2 => Verify(rec2, testRecord2A))));
     }
@@ -41,13 +37,13 @@ public class FluentVerifierTests
                                  x.DoSomethingAsyncWithResultAsync(It.Is<TestRecord1>(rec1 =>
                                                                                           FluentVerifier.VerifyFluentAssertion(() => rec1.IntProperty.Should()
                                                                                                                                          .Be(testRecord1A
-                                                                                                                                                 .IntProperty, "test", 1))),
+                                                                                                                                                 .IntProperty))),
                                                                    It.Is<TestRecord2>(rec2 =>
                                                                                           FluentVerifier.VerifyFluentAssertion(() => rec2.RecordProperty1
                                                                                                                                          .IntProperty.Should()
                                                                                                                                          .Be(testRecord2A
                                                                                                                                              .RecordProperty1
-                                                                                                                                             .IntProperty, "test", 2)))),
+                                                                                                                                             .IntProperty)))),
                              Times.Once);
     }
 

--- a/tests/TestingSupport.XUnit3.Tests/TestData/JsonFileDataAttributeTests.cs
+++ b/tests/TestingSupport.XUnit3.Tests/TestData/JsonFileDataAttributeTests.cs
@@ -8,7 +8,7 @@ namespace Ploch.TestingSupport.XUnit3.Tests.TestData;
 public class JsonFileDataAttributeTests
 {
     [Theory]
-    [JsonFileData("TestData/TestData.json", "Student")]
+    [JsonFileData("TestData/TestData.json", nameof(Student))]
     public void EnrollStudent_Success(Student student, int id)
     {
         if (id == 0)


### PR DESCRIPTION
## **User description**
## Describe your changes

Cleans up the entire backlog of pre-existing analyzer warnings across the **test projects** so that future regressions stand out in the build output. The test-project warning count went from **~814 to 0** — every test assembly now builds clean.

This PR is **test-only**: no shipping-library (`src/`) code was modified, so there is **no consumer-visible behaviour change**.

### Approach (per the issue's "balanced" policy)

The issue asked to *"prefer real fixes over blanket suppressions; where a rule genuinely does not apply to test code, adjust the analyzer config with justification rather than per-line pragmas."* That is exactly what was done:

**Real in-code fixes** — preferred wherever the warning pointed at a genuine issue. Several were actual bugs:
- `CS1696` — a malformed `#pragma warning disable` directive (explanatory text was not commented).
- `CA2241` — a `FluentAssertions` call passing extra values as `because`/`becauseArgs` with no matching format placeholder.
- `CS0252` — an unintended reference comparison where a `(string)` cast was intended (matching the sibling assertions).
- `S1125` — a redundant `== true` boolean comparison.
- `S4144` — a duplicate test method (identical body to an existing test; `TypeLoader` has no public constructor, so the "constructor" test was a copy of the `Configure` test).

The remaining in-code fixes were mechanical and behaviour-preserving: `nameof(...)` over string literals, `var` usage, `string.Empty` over `""`, member-group conversions, member/using ordering, comment spacing, dead-code and redundant-local removal, `DateTime.UnixEpoch` over a manual epoch construction, and consistent collection-initialiser indentation.

**Analyzer config scoping** (`tests/.editorconfig`, each entry carries a justifying comment) — used **only** for rules inherently inapplicable to non-shipping test assemblies, and for a small set of false positives on deliberately-shaped fixtures:
- XML-doc rules, argument-validation rules, async-suffix/threading rules — not meaningful for test code.
- A handful of rules (e.g. `S3878`, fixture-shape rules) that fire as false positives on reflection/serialization **test fixtures** whose "smells" are the subject under test, not accidental misuse. Example: `S3878` mis-fires on a collection expression that *must* be passed as a named `params` argument (the record has leading optional parameters, so params-expansion syntax is impossible).

All scoping lives in the **nested** `tests/.editorconfig`, which cascades over the repo root config — so `src/` analysis is completely unaffected.

## Design Decisions

- **Scope limited to test projects.** The issue's premise (most warnings in test code) was partly inaccurate — a large share of the total lives in the shipping libraries under `src/`. Per the agreed scope, this PR cleans **test projects only**; the shipping-library cleanup is tracked in a dedicated follow-up, **#242**, so the two concerns stay reviewable in isolation.
- **Config in `tests/.editorconfig`, not the repo root.** The nested file is the canonical place for test-scoped analyzer configuration: it cascades over the root for matching keys and keeps `src/` analysis pristine. (An early attempt placed scoping in the root `.editorconfig`; it was reverted in favour of the nested file.)
- **`SA1508`/`AD0001`.** `AD0001` was an analyzer (`SA1508`) crashing on test compilations; disabling `SA1508` for tests removes the crash there while leaving it active for `src/`.
- **A few code-cracker/Sonar false positives** were resolved with tiny behaviour-preserving code changes rather than suppressions (e.g. a fixture string suffix that collided with an accessible symbol name; `CC0105` "use var" on `int x = default;`, which cannot use `var` with a bare `default`, rewritten to `var x = default(int)` — aligning with the repo's `var`-for-built-in-types style).

## Testing

- `dotnet build Ploch.Common.slnx -c Debug` → **0 errors, 0 test-project warnings** (remaining warnings are all in `src/`, tracked in #242).
- `dotnet test Ploch.Common.slnx` → **all pass, 0 failures** (2 110+ tests across net8.0/net10.0 assemblies; the 6 skips are pre-existing `[Fact(Skip=...)]` unrelated to this change).
- No new tests were added — this is an analyzer-warning cleanup with no behavioural change. The one removed test (`S4144`) was an exact duplicate.

## Breaking Changes

None. Test-only change; no public API, behaviour, or shipping-library code affected.

## Related

- Refs #233
- Follow-up: #242 (clean the equivalent warnings in the shipping `src/` libraries)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. *(N/A — analyzer cleanup, no behaviour change; all existing tests pass)*
- [ ] Do we need to implement analytics? *(N/A)*
- [ ] Will this be part of a product update? *(N/A — test-only, no consumer-visible change)*

> Note: external review by Codex/Gemini was unavailable during this work (Codex rejected the ChatGPT-account models; Gemini quota exhausted), so this PR relies on local self-review plus the CI bot suite.

## Summary by Sourcery

Clean up pre-existing analyzer warnings across test projects with test-only code and configuration adjustments.

Bug Fixes:
- Fix incorrect FluentAssertions usage, parameter name expectations, and other minor test bugs identified by analyzers.
- Remove a duplicate TypeLoader test and correct test data and assertions to align with intended semantics.

Enhancements:
- Apply mechanical, behavior-preserving refactors in test code (e.g., nameof usage, string.Empty, var, justification comments, and formatting) to satisfy analyzers and improve consistency.
- Adjust ReSharper suppression attributes and add justifications for intentionally shaped reflection/serialization test fixtures.
- Reorder and tidy global usings and minor test helpers for clearer structure.

Documentation:
- Add a change-log entry documenting the test-project analyzer warning cleanup and its scope.

Tests:
- Tidy up and simplify several test implementations and fixtures while keeping overall test coverage and behavior unchanged.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Cleaned up pre-existing analyzer warnings across all test projects, reducing the warning count from ~814 to 0.</li>
<li>Applied real code fixes for issues like malformed pragmas, argument mismatches, and redundant code instead of just suppressing warnings.</li>
<li>Updated `tests/.editorconfig` to scope out analyzer rules that are inapplicable to test assemblies, such as documentation and async naming conventions.</li>
<li>Ensured that analyzer scoping only affects test projects and does not impact shipping library code in `src/`.</li>
</ul></div>


___

## **CodeAnt-AI Description**
Clean up test-project analyzer warnings and fix a few broken test cases

### What Changed
- Removed the pre-existing analyzer warning backlog from the test projects so test builds now report cleanly
- Fixed a handful of real test issues, including a bad pragma comment, a mismatched assertion message, an incorrect comparison, a redundant boolean check, and a duplicate test
- Replaced hard-coded names and empty strings with clearer equivalents in tests, and tightened several assertions and fixtures for consistency
- Scoped analyzer rules in `tests/.editorconfig` for test-only cases where shipping-style rules do not apply, with comments explaining each exception

### Impact
`✅ Cleaner test builds`
`✅ Easier to spot new test regressions`
`✅ Fewer false-positive analyzer warnings in test-only code`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new change-log entry describing the test-only analyzer warning cleanup and the resulting warning count reduction.

* **Chores**
  * Updated analyzer severity rules for test projects to reduce noisy reports and false positives, scoped to tests.
  * Reordered shared global imports for consistency.
  * Reformatted/adjusted several test fixtures and sample types without changing expected behavior.

* **Tests**
  * Improved robustness of assertions (e.g., `nameof`, `string.Empty`, fixed date constants).
  * Simplified some delegate and lambda usage in idempotency/process-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->