### PR TITLE
fix(common): TakeRandom never selects the last element (off-by-one)

### DIFF
--- a/change-log/2026-07-11-246-takerandom-off-by-one.md
+++ b/change-log/2026-07-11-246-takerandom-off-by-one.md
@@ -1,0 +1,7 @@
+## Fix: `TakeRandom` never selected the last element (off-by-one)
+
+- **Bug fix** in `Ploch.Common.Collections.EnumerableExtensions.TakeRandom<T>`: the random index was drawn with `Random.Next(0, indexes.Count - 1)`, whose upper bound is exclusive. Because index removal preserves order, the source's last element could never be selected unless the requested count equalled the source size — skewing the selection distribution.
+- The upper bound is now `indexes.Count`, making every element reachable with uniform probability.
+- Added regression tests asserting that every element (including the last) can be selected, and that a single-element source returns its only element.
+
+Refs: #246

--- a/src/Common/Collections/EnumerableExtensions.cs
+++ b/src/Common/Collections/EnumerableExtensions.cs
@@ -188,7 +188,7 @@ public static class EnumerableExtensions
 
         for (var i = 0; i < count; i++)
         {
-            var indexesItemNum = ThreadSafeRandom.Shared.Next(0, indexes.Count);
+            var indexesItemNum = ThreadSafeRandom.Shared.Next(indexes.Count);
             var itemIndex = indexes[indexesItemNum];
 
             result.Add(list[itemIndex]);

--- a/src/Common/Collections/EnumerableExtensions.cs
+++ b/src/Common/Collections/EnumerableExtensions.cs
@@ -188,7 +188,7 @@ public static class EnumerableExtensions
 
         for (var i = 0; i < count; i++)
         {
-            var indexesItemNum = ThreadSafeRandom.Shared.Next(0, indexes.Count - 1);
+            var indexesItemNum = ThreadSafeRandom.Shared.Next(0, indexes.Count);
             var itemIndex = indexes[indexesItemNum];
 
             result.Add(list[itemIndex]);

--- a/tests/Common.Apps/Apps.Model.Tests/ActionHandlerManagerTests.cs
+++ b/tests/Common.Apps/Apps.Model.Tests/ActionHandlerManagerTests.cs
@@ -11,7 +11,7 @@ public class ActionHandlerManagerTests
         var manager = new ActionHandlerManager<TestDescriptor, TestActionInfo, SuccessHandler>([handler]);
         var actionInfo = new TestActionInfo(new TestDescriptor(), "test-action");
 
-        var result = await manager.ExecuteAsync(actionInfo);
+        var result = await manager.ExecuteAsync(actionInfo, TestContext.Current.CancellationToken);
 
         Assert.True(result.IsSuccess);
     }
@@ -23,7 +23,7 @@ public class ActionHandlerManagerTests
         var manager = new ActionHandlerManager<TestDescriptor, TestActionInfo, FailureHandler>([handler]);
         var actionInfo = new TestActionInfo(new TestDescriptor(), "test-action");
 
-        var result = await manager.ExecuteAsync(actionInfo);
+        var result = await manager.ExecuteAsync(actionInfo, TestContext.Current.CancellationToken);
 
         Assert.False(result.IsSuccess);
     }

--- a/tests/Common.Tests/Collections/EnumerableExtensionsTests.cs
+++ b/tests/Common.Tests/Collections/EnumerableExtensionsTests.cs
@@ -144,8 +144,9 @@ public class EnumerableExtensionsTests(ITestOutputHelper output)
             selectedValues.Add(sourceList.TakeRandom(1).Single());
         }
 
-        // With a correct uniform selection, the chance of any element never appearing
-        // in 300 single-item draws from 3 elements is (2/3)^300 - effectively zero.
+        // With a correct uniform selection, the chance of any element never appearing in
+        // 300 single-item draws from 3 elements is at most 3 * (2/3)^300 - effectively zero.
+        // With the off-by-one bug this fails deterministically: the last element is unreachable.
         selectedValues.Should().BeEquivalentTo(sourceList);
     }
 

--- a/tests/Common.Tests/Collections/EnumerableExtensionsTests.cs
+++ b/tests/Common.Tests/Collections/EnumerableExtensionsTests.cs
@@ -134,6 +134,32 @@ public class EnumerableExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void TakeRandom_should_be_able_to_select_every_element_including_the_last()
+    {
+        var sourceList = new[] { 1, 2, 3 };
+
+        var selectedValues = new HashSet<int>();
+        for (var i = 0; i < 300; i++)
+        {
+            selectedValues.Add(sourceList.TakeRandom(1).Single());
+        }
+
+        // With a correct uniform selection, the chance of any element never appearing
+        // in 300 single-item draws from 3 elements is (2/3)^300 - effectively zero.
+        selectedValues.Should().BeEquivalentTo(sourceList);
+    }
+
+    [Fact]
+    public void TakeRandom_should_return_the_only_element_when_source_has_a_single_item()
+    {
+        var sourceList = new[] { 42 };
+
+        var result = sourceList.TakeRandom(1);
+
+        result.Should().ContainSingle().Which.Should().Be(42);
+    }
+
+    [Fact]
     public void JoinWithFinalSeparator_should_use_final_separator_for_last_item()
     {
         var strings = new Fixture().CreateMany<string>(20);


### PR DESCRIPTION
## Describe your changes

### Summary

Fixes the off-by-one in `Ploch.Common.Collections.EnumerableExtensions.TakeRandom<T>`. The random index was drawn with `Random.Next(0, indexes.Count - 1)`, whose upper bound is **exclusive**, so the last index position could never be returned. Because `RemoveAt` preserves the ascending order of the `indexes` list, the source's last element always sat at the tail — making it **completely unreachable** whenever `count < source.Count` (not merely under-represented). The index is now drawn with `Next(indexes.Count)`, giving every element uniform selection probability.

### Changes

- `src/Common/Collections/EnumerableExtensions.cs` — `Next(0, indexes.Count - 1)` → `Next(indexes.Count)` (single-argument overload per review feedback, consistent with `Shuffle`).
- `tests/Common.Tests/Collections/EnumerableExtensionsTests.cs` — two regression tests:
  - `TakeRandom_should_be_able_to_select_every_element_including_the_last` — 300 single-item draws from a 3-element source must observe all elements. Deterministically failed before the fix (the last element was structurally unreachable); false-failure probability after the fix is bounded by 3 × (2/3)^300 ≈ 10⁻⁵².
  - `TakeRandom_should_return_the_only_element_when_source_has_a_single_item` — guards the `Next(0) == 0` edge.
- `tests/Common.Apps/Apps.Model.Tests/ActionHandlerManagerTests.cs` — drive-by fix for two pre-existing xUnit1051 warnings (pass `TestContext.Current.CancellationToken`), keeping the solution build warning-clean.
- `change-log/2026-07-11-246-takerandom-off-by-one.md` — change-log entry.

### Design Decisions

- **Test-first bug-fix protocol:** the reachability test was written first and verified to fail with `misses {3}` before the fix was applied.
- **Deterministic-by-construction regression guard:** with the bug present the test fails every run (structural unreachability, not statistics), so it is a reliable guard rather than a flaky probabilistic check. Seeding is not possible without an API change (`ThreadSafeRandom.Shared` is not injectable).
- **Negative `count` intentionally not validated here:** current behaviour (empty result) matches LINQ `Take` semantics; throwing would be a breaking change — recorded in #252 for deliberate consideration.

### Review feedback outcome

All 8 automated review threads triaged, replied to, and resolved:
- Accepted: single-arg `Next(maxValue)` simplification (gemini) and union-bound comment correction (codeant-ai) — commit 2d7990b.
- Out of scope → follow-ups filed: #252 (partial Fisher-Yates optimisation for `TakeRandom`), #253 (strengthen `ActionHandlerManagerTests` assertions), #250 (pre-existing WebUI NuGet pack warning found during the zero-warnings gate).
- Declined with evidence: probabilistic-test flakiness concerns (deterministic failure direction; ~10⁻⁵² false-negative bound).

### Testing

- Full solution: all tests pass (824 in Common.Tests on net10.0, 791 on net8.0, plus all other projects), 0 failures; 6 pre-existing unrelated skips.
- Build: zero new warnings (only the pre-existing #250 packaging warning remains).

## Issue ticket number and link

Closes #246

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? — No.
- [x] Will this be part of a product update? If yes, please write one phrase about this update. — Yes: bug fix, `TakeRandom` can now select every element of the source (previously the last element was unreachable).