### PR TITLE
fix(common): Harden JoinWithFinalSeparator and SelectListHelper edge cases

### DIFF
--- a/change-log/2026-07-11-248-joinwithfinalseparator-selectlist-edge-cases.md
+++ b/change-log/2026-07-11-248-joinwithfinalseparator-selectlist-edge-cases.md
@@ -1,0 +1,7 @@
+## Fix: Harden `JoinWithFinalSeparator` and `SelectListHelper` edge cases
+
+- **Bug fix** in `Ploch.Common.Collections.EnumerableExtensions.JoinWithFinalSeparator`: an empty source threw `IndexOutOfRangeException` and a single-element source incorrectly prepended the final separator (e.g. `" and x"`). An empty source now returns `string.Empty` and a single-element source returns just that element, matching `string.Join` boundary semantics.
+- **Bug fix** in `Ploch.Common.WebUI.TagUtilities.SelectListHelper.CreateFor`: a `textFunc`/`valueFunc` delegate returning `null` for an item caused a `NullReferenceException`. Null delegate results now map to `string.Empty` for the item's `Text`/`Value`.
+- Added regression tests for the empty, single-element, and two-element `JoinWithFinalSeparator` boundaries and for null `SelectListItem` text/value delegate results.
+
+Refs: #248

--- a/src/Common.WebUI.Tests/TagUtilities/SelectListHelperTests.cs
+++ b/src/Common.WebUI.Tests/TagUtilities/SelectListHelperTests.cs
@@ -25,6 +25,18 @@ public class SelectListHelperTests
                         .BeEquivalentTo(expectedItems);
     }
 
+    [Fact]
+    public void CreateFor_should_map_null_delegate_results_to_empty_text_and_value()
+    {
+        var testModels = new List<TestModel> { new() { MyText = null, MyValue = null } };
+
+        var result = SelectListHelper.CreateFor(testModels, m => m.MyText!, m => m.MyValue!);
+
+        result.Should().ContainSingle();
+        result[0].Text.Should().BeEmpty();
+        result[0].Value.Should().BeEmpty();
+    }
+
     public class TestModel
     {
         public string? MyValue { get; set; }

--- a/src/Common.WebUI/TagUtilities/SelectListHelper.cs
+++ b/src/Common.WebUI/TagUtilities/SelectListHelper.cs
@@ -45,7 +45,7 @@ public static class SelectListHelper
 
         // ReSharper disable once PossibleMultipleEnumeration - false-positive
 #pragma warning disable CC0031 // Check for null before calling a delegate - false-positive
-        var result = items.Select(item => new SelectListItem(textFunc(item).ToString(), valueFunc(item).ToString())).ToList();
+        var result = items.Select(item => new SelectListItem(textFunc(item)?.ToString() ?? string.Empty, valueFunc(item)?.ToString() ?? string.Empty)).ToList();
 #pragma warning restore CC0031
         if (includeNull)
         {

--- a/src/Common.WebUI/TagUtilities/SelectListHelper.cs
+++ b/src/Common.WebUI/TagUtilities/SelectListHelper.cs
@@ -19,11 +19,11 @@ public static class SelectListHelper
     /// <param name="items">The source collection.</param>
     /// <param name="textFunc">
     ///     Function mapping an item to the <see cref="SelectListItem.Text" /> property of a
-    ///     <see cref="SelectListItem" />.
+    ///     <see cref="SelectListItem" />. A <see langword="null" /> result maps to <see cref="string.Empty" />.
     /// </param>
     /// <param name="valueFunc">
     ///     Function mapping an item to the <see cref="SelectListItem.Value" /> property of a
-    ///     <see cref="SelectListItem" />.
+    ///     <see cref="SelectListItem" />. A <see langword="null" /> result maps to <see cref="string.Empty" />.
     /// </param>
     /// <param name="includeNull">
     ///     If <c>True</c> then <c>string.Empty</c> value entry will be added to the result

--- a/src/Common/Collections/EnumerableExtensions.cs
+++ b/src/Common/Collections/EnumerableExtensions.cs
@@ -134,7 +134,7 @@ public static class EnumerableExtensions
     {
         source.NotNull(nameof(source));
         valueSelector.NotNull(nameof(valueSelector));
-        var listSource = source as IReadOnlyList<TValue> ?? source.ToArray();
+        var listSource = source as IReadOnlyList<TValue> ?? [.. source];
         var count = listSource.Count;
 
         if (count <= 1)

--- a/src/Common/Collections/EnumerableExtensions.cs
+++ b/src/Common/Collections/EnumerableExtensions.cs
@@ -108,7 +108,10 @@ public static class EnumerableExtensions
     /// <param name="separator">The separator.</param>
     /// <param name="finalSeparator">The final separator.</param>
     /// <typeparam name="TValue">The type of the collection element.</typeparam>
-    /// <returns>String from joined elements.</returns>
+    /// <returns>
+    ///     String from joined elements. An empty source yields <see cref="string.Empty" />; a single-element
+    ///     source yields that element without any separator.
+    /// </returns>
     public static string JoinWithFinalSeparator<TValue>(this IEnumerable<TValue> source, string separator, string finalSeparator)
     {
         return source.JoinWithFinalSeparator(separator, finalSeparator, static v => v?.ToString());

--- a/src/Common/Collections/EnumerableExtensions.cs
+++ b/src/Common/Collections/EnumerableExtensions.cs
@@ -123,7 +123,10 @@ public static class EnumerableExtensions
     /// <param name="separator">The separator to be used between elements.</param>
     /// <param name="finalSeparator">The separator to be used between the last two elements.</param>
     /// <param name="valueSelector">A function to select a result value from each element.</param>
-    /// <returns>A string that consists of the joined elements with the separators.</returns>
+    /// <returns>
+    ///     A string that consists of the joined elements with the separators. An empty source yields
+    ///     <see cref="string.Empty" />; a single-element source yields that element without any separator.
+    /// </returns>
     public static string JoinWithFinalSeparator<TValue, TResult>(this IEnumerable<TValue> source,
                                                                  string separator,
                                                                  string finalSeparator,
@@ -133,6 +136,11 @@ public static class EnumerableExtensions
         valueSelector.NotNull(nameof(valueSelector));
         var arraySource = source as TValue[] ?? source.ToArray();
         var count = arraySource.Length;
+
+        if (count <= 1)
+        {
+            return arraySource.Join(separator, valueSelector);
+        }
 
 #pragma warning disable CC0031, IDE0056 // index-from-end operator unavailable on netstandard2.0
         return arraySource.Take(count - 1).Join(separator, valueSelector) + finalSeparator + valueSelector(arraySource[arraySource.Length - 1]); // skipcq: CS-R1019 - index-from-end operator unavailable on netstandard2.0

--- a/src/Common/Collections/EnumerableExtensions.cs
+++ b/src/Common/Collections/EnumerableExtensions.cs
@@ -134,16 +134,16 @@ public static class EnumerableExtensions
     {
         source.NotNull(nameof(source));
         valueSelector.NotNull(nameof(valueSelector));
-        var arraySource = source as TValue[] ?? source.ToArray();
-        var count = arraySource.Length;
+        var listSource = source as IReadOnlyList<TValue> ?? source.ToArray();
+        var count = listSource.Count;
 
         if (count <= 1)
         {
-            return arraySource.Join(separator, valueSelector);
+            return listSource.Join(separator, valueSelector);
         }
 
 #pragma warning disable CC0031, IDE0056 // index-from-end operator unavailable on netstandard2.0
-        return arraySource.Take(count - 1).Join(separator, valueSelector) + finalSeparator + valueSelector(arraySource[arraySource.Length - 1]); // skipcq: CS-R1019 - index-from-end operator unavailable on netstandard2.0
+        return listSource.Take(count - 1).Join(separator, valueSelector) + finalSeparator + valueSelector(listSource[count - 1]); // skipcq: CS-R1019 - index-from-end operator unavailable on netstandard2.0
 #pragma warning restore CC0031, IDE0056
     }
 

--- a/tests/Common.Tests/Collections/EnumerableExtensionsTests.cs
+++ b/tests/Common.Tests/Collections/EnumerableExtensionsTests.cs
@@ -173,6 +173,30 @@ public class EnumerableExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void JoinWithFinalSeparator_should_return_empty_string_for_empty_source()
+    {
+        var result = Array.Empty<string>().JoinWithFinalSeparator(", ", " and ");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void JoinWithFinalSeparator_should_return_the_only_element_without_separators_for_single_element_source()
+    {
+        var result = new[] { "only" }.JoinWithFinalSeparator(", ", " and ");
+
+        result.Should().Be("only");
+    }
+
+    [Fact]
+    public void JoinWithFinalSeparator_should_use_only_final_separator_for_two_element_source()
+    {
+        var result = new[] { 1, 2 }.JoinWithFinalSeparator(", ", " and ");
+
+        result.Should().Be("1 and 2");
+    }
+
+    [Fact]
     public void If_should_extend_the_query_with_a_provided_query_if_the_condition_is_met()
     {
         var items = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };


### PR DESCRIPTION
## **User description**
## Describe your changes

### Summary

Hardens two pre-existing edge cases surfaced by review bots during #245, per the prescriptions in #248. Both are correctness fixes in shipping code targeted for the v4.0 stable release.

### Changes

- `src/Common/Collections/EnumerableExtensions.cs` — `JoinWithFinalSeparator<TValue, TResult>`:
  - **Empty source** previously indexed `arraySource[-1]` → `IndexOutOfRangeException`; now returns `string.Empty`.
  - **Single element** previously returned `finalSeparator + element` (e.g. `" and x"`); now returns just the element.
  - Implemented as a single `count <= 1` branch that falls back to the existing `Join` overload, so boundary behaviour matches `string.Join` semantics exactly. XML `<returns>` doc updated to document the boundary behaviour.
  - Per review feedback (`1486e0f`): the source is consumed via `IReadOnlyList<TValue>` instead of being copied to an array, avoiding the allocation for arrays/`List<T>`.
- `src/Common.WebUI/TagUtilities/SelectListHelper.cs` — `CreateFor<TModel>`: `textFunc(item).ToString()` / `valueFunc(item).ToString()` threw `NullReferenceException` when a delegate returned `null`; now `?.ToString() ?? string.Empty`, so null results render as empty `Text`/`Value`.
- Regression tests (test-first — each verified failing before the fix):
  - `JoinWithFinalSeparator_should_return_empty_string_for_empty_source` (failed with `IndexOutOfRangeException`)
  - `JoinWithFinalSeparator_should_return_the_only_element_without_separators_for_single_element_source` (failed with `" and only"`)
  - `JoinWithFinalSeparator_should_use_only_final_separator_for_two_element_source` (boundary guard)
  - `CreateFor_should_map_null_delegate_results_to_empty_text_and_value` (failed with `NullReferenceException`)
- `change-log/2026-07-11-248-joinwithfinalseparator-selectlist-edge-cases.md` — change-log entry for the v4.0 release notes.

### Design Decisions

- **`string.Join` boundary semantics** for empty/single sources (empty → `""`, single → bare element) rather than throwing: consistent with the BCL and the natural rendering for human-readable lists. Shipping in v4.0 makes the throw→`""` change acceptable.
- **Null delegate results → `string.Empty`**: `SelectListItem.Text`/`Value` are non-nullable-annotated, and an empty option entry is the neutral rendering.
- **`ToString()` conversion contract kept:** a review suggestion to use `as string` was declined — it would silently discard non-string delegate results (the API deliberately accepts `Func<TModel, object>`).
- **Codex/Gemini plan review skipped (documented deviation):** the Codex CLI rejects all models on the current ChatGPT account and Gemini's free-tier quota is exhausted, so the external second-opinion gate could not run. The fixes are prescribed verbatim in #248 and the PR bot fleet provides independent review.

### Review feedback outcome

All 4 automated review threads triaged, replied to, and resolved:
- Accepted: `IReadOnlyList<TValue>` optimisation (gemini-code-assist) — commit `1486e0f`.
- Declined with reasoning: `as string` conversion change (behavioural regression); full streaming rewrite (out of scope; lookahead complexity vs. short human-readable inputs — partially addressed by the accepted optimisation).
- False positive: codeant-ai's claim that the change-log entry violates the ContextStream rule — `change-log/` is the repo convention (`.claude/rules/change-log.md`) that feeds release-notes generation in `release.yml`.

### Testing

- Full solution: all tests pass (827 in Common.Tests net10.0 / 794 net8.0 incl. 3 new; 3 in WebUI.Tests incl. 1 new), 0 failures, 6 pre-existing unrelated skips.
- Build: zero new warnings (only the pre-existing #250 packaging warning).

## Issue ticket number and link

Closes #248

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? — No.
- [x] Will this be part of a product update? If yes, please write one phrase about this update. — Yes: bug fixes — `JoinWithFinalSeparator` handles empty/single-element sources correctly, and `SelectListHelper.CreateFor` no longer throws on null text/value delegate results.


___

## **CodeAnt-AI Description**
Fix edge cases in list joining and select-list item text/value handling

### What Changed
- Joining items with a final separator now works for empty and single-item lists: empty lists return an empty string, and one-item lists return just that item.
- Select-list items now handle null text or value results by showing an empty string instead of failing.
- Added regression tests for empty, single-item, and two-item joins, plus null select-list results.
- Added a release note entry for these fixes.

### Impact
`✅ Fewer crashes on empty lists`
`✅ Correct one-item join output`
`✅ Clearer select-list rendering when values are missing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
