### PR TITLE
fix(common): Cap processor affinity at the native mask width

### DIFF
--- a/change-log/2026-07-12-249-processextensions-affinity-mask-width.md
+++ b/change-log/2026-07-12-249-processextensions-affinity-mask-width.md
@@ -1,0 +1,28 @@
+# fix(common): ProcessExtensions affinity mask respects the native mask width
+
+**Issue:** [#249](https://github.com/mrploch/ploch-common/issues/249)
+
+## Summary
+
+`SetSingleProcessorAffinity`, `SetEnabledProcessors` and `GetEnabledProcessors` in
+`Ploch.Common.Diagnostics.ProcessExtensions` validated processor numbers only against
+`Environment.ProcessorCount`, ignoring the width of the native `Process.ProcessorAffinity`
+bitmask (`IntPtr.Size * 8`). On machines with more than 64 logical processors the
+`1L << n` shift wrapped (`n & 63`), setting the wrong bit; in a 32-bit process, bits
+32–63 were silently truncated and `GetEnabledProcessors` mis-reported.
+
+## Changes
+
+- Processor numbers are now validated against the lesser of `Environment.ProcessorCount`
+  and the native affinity-mask width. Unaddressable processor numbers throw
+  `ArgumentOutOfRangeException` with a message stating both limits.
+- `GetEnabledProcessors` bounds its read loop the same way, so it never reports
+  processors that cannot be represented in the mask.
+
+## Behaviour change (not breaking for supported configurations)
+
+Previously, on hardware/process combinations where a processor number passed the
+`ProcessorCount` check but exceeded the mask width, the methods silently applied a
+wrong affinity mask. These calls now throw `ArgumentOutOfRangeException`. On machines
+with ≤64 logical processors running 64-bit processes (the overwhelmingly common case)
+behaviour is unchanged.

--- a/src/Common/Diagnostics/ProcessExtensions.cs
+++ b/src/Common/Diagnostics/ProcessExtensions.cs
@@ -126,7 +126,8 @@ public static class ProcessExtensions
         // call time instead of being deferred until the sequence is enumerated.
         var affinityMask = process.ProcessorAffinity.ToInt64();
         var enabledProcessors = new List<int>();
-        for (var i = 0; i < MaxAddressableProcessors; i++)
+        var maxAddressableProcessors = MaxAddressableProcessors;
+        for (var i = 0; i < maxAddressableProcessors; i++)
         {
             if ((affinityMask & (1L << i)) != 0)
             {

--- a/src/Common/Diagnostics/ProcessExtensions.cs
+++ b/src/Common/Diagnostics/ProcessExtensions.cs
@@ -11,13 +11,35 @@ namespace Ploch.Common.Diagnostics;
 public static class ProcessExtensions
 {
     /// <summary>
+    /// Gets the width, in bits, of the native <see cref="Process.ProcessorAffinity"/> mask for the current process
+    /// (32 in a 32-bit process, 64 in a 64-bit process).
+    /// </summary>
+    private static int AffinityMaskWidth => IntPtr.Size * 8;
+
+    /// <summary>
+    /// Gets the exclusive upper bound for addressable processor numbers: the lesser of
+    /// <see cref="Environment.ProcessorCount"/> and <see cref="AffinityMaskWidth"/>.
+    /// </summary>
+    private static int MaxAddressableProcessors => GetMaxAddressableProcessors(Environment.ProcessorCount, AffinityMaskWidth);
+
+    /// <summary>
     /// Sets the processor affinity of the process to a single processor specified by <paramref name="processorNumber"/>.
     /// </summary>
     /// <param name="process">The process whose affinity will be set.</param>
     /// <param name="processorNumber">The zero-based processor number to set affinity to.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="process"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="processorNumber"/> is out of range.</exception>
-    /// <remarks>Processor affinity is only supported on Windows and Linux; calling this on other platforms throws <see cref="PlatformNotSupportedException"/>.</remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="processorNumber"/> is negative, or not below the lesser of
+    /// <see cref="Environment.ProcessorCount"/> and the native affinity-mask width (<c>IntPtr.Size * 8</c>).
+    /// </exception>
+    /// <remarks>
+    /// Processor affinity is only supported on Windows and Linux; calling this on other platforms throws <see cref="PlatformNotSupportedException"/>.
+    /// <para>
+    /// <see cref="Process.ProcessorAffinity"/> is a pointer-sized bitmask, so processors beyond the native pointer width cannot be
+    /// addressed — for example processors 32 and above in a 32-bit process, or 64 and above on machines with more than
+    /// 64 logical processors. Such processor numbers are rejected with <see cref="ArgumentOutOfRangeException"/>.
+    /// </para>
+    /// </remarks>
 #if NET5_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     [System.Runtime.Versioning.SupportedOSPlatform("linux")]
@@ -26,10 +48,7 @@ public static class ProcessExtensions
     {
         process.NotNull(nameof(process));
 
-        if (processorNumber < 0 || processorNumber >= Environment.ProcessorCount)
-        {
-            throw new ArgumentOutOfRangeException(nameof(processorNumber), "Processor number must be within valid range.");
-        }
+        ValidateProcessorNumber(processorNumber, Environment.ProcessorCount, AffinityMaskWidth, nameof(processorNumber));
 
         var affinityMask = 1L << processorNumber;
 #pragma warning disable CA2020 // Unchecked is intentional: the affinity bitmask's high bit (e.g. processor 31 on a 32-bit process) must wrap to the native pointer pattern, not throw OverflowException.
@@ -44,8 +63,18 @@ public static class ProcessExtensions
     /// <param name="enabledProcessorsNumbers">An array of zero-based processor numbers to enable.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="process"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown if no processor numbers are specified.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if any processor number is out of range.</exception>
-    /// <remarks>Processor affinity is only supported on Windows and Linux; calling this on other platforms throws <see cref="PlatformNotSupportedException"/>.</remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if any processor number is negative, or not below the lesser of
+    /// <see cref="Environment.ProcessorCount"/> and the native affinity-mask width (<c>IntPtr.Size * 8</c>).
+    /// </exception>
+    /// <remarks>
+    /// Processor affinity is only supported on Windows and Linux; calling this on other platforms throws <see cref="PlatformNotSupportedException"/>.
+    /// <para>
+    /// <see cref="Process.ProcessorAffinity"/> is a pointer-sized bitmask, so processors beyond the native pointer width cannot be
+    /// addressed — for example processors 32 and above in a 32-bit process, or 64 and above on machines with more than
+    /// 64 logical processors. Such processor numbers are rejected with <see cref="ArgumentOutOfRangeException"/>.
+    /// </para>
+    /// </remarks>
 #if NET5_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     [System.Runtime.Versioning.SupportedOSPlatform("linux")]
@@ -59,14 +88,10 @@ public static class ProcessExtensions
             throw new ArgumentException("At least one processor number must be specified.", nameof(enabledProcessorsNumbers));
         }
 
-        var processorCount = Environment.ProcessorCount;
         long affinityMask = 0;
         foreach (var number in enabledProcessorsNumbers)
         {
-            if (number < 0 || number >= processorCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(enabledProcessorsNumbers), $"Processor number {number} is out of range.");
-            }
+            ValidateProcessorNumber(number, Environment.ProcessorCount, AffinityMaskWidth, nameof(enabledProcessorsNumbers));
 
             affinityMask |= 1L << number;
         }
@@ -82,7 +107,13 @@ public static class ProcessExtensions
     /// <param name="process">The process to query.</param>
     /// <returns>An enumerable of zero-based processor numbers that are enabled for the process.</returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="process"/> is <see langword="null"/>.</exception>
-    /// <remarks>Processor affinity is only supported on Windows and Linux; calling this on other platforms throws <see cref="PlatformNotSupportedException"/>.</remarks>
+    /// <remarks>
+    /// Processor affinity is only supported on Windows and Linux; calling this on other platforms throws <see cref="PlatformNotSupportedException"/>.
+    /// <para>
+    /// Only processors representable in the native <see cref="Process.ProcessorAffinity"/> bitmask are reported — at most
+    /// <c>IntPtr.Size * 8</c> processors (32 in a 32-bit process, 64 in a 64-bit process).
+    /// </para>
+    /// </remarks>
 #if NET5_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     [System.Runtime.Versioning.SupportedOSPlatform("linux")]
@@ -95,7 +126,7 @@ public static class ProcessExtensions
         // call time instead of being deferred until the sequence is enumerated.
         var affinityMask = process.ProcessorAffinity.ToInt64();
         var enabledProcessors = new List<int>();
-        for (var i = 0; i < Environment.ProcessorCount; i++)
+        for (var i = 0; i < MaxAddressableProcessors; i++)
         {
             if ((affinityMask & (1L << i)) != 0)
             {
@@ -104,5 +135,42 @@ public static class ProcessExtensions
         }
 
         return enabledProcessors;
+    }
+
+    /// <summary>
+    /// Gets the number of processors addressable in the affinity mask: the lesser of
+    /// <paramref name="processorCount"/> and <paramref name="affinityMaskWidth"/>.
+    /// </summary>
+    /// <param name="processorCount">The number of logical processors on the machine.</param>
+    /// <param name="affinityMaskWidth">The width, in bits, of the native affinity mask.</param>
+    /// <returns>The exclusive upper bound for addressable processor numbers.</returns>
+    /// <remarks>
+    /// Internal (rather than private) so the mask-width capping can be unit-tested with limits that do not occur on the
+    /// test machine — more than 64 logical processors, or the 32-bit-process mask width.
+    /// </remarks>
+    internal static int GetMaxAddressableProcessors(int processorCount, int affinityMaskWidth) => Math.Min(processorCount, affinityMaskWidth);
+
+    /// <summary>
+    /// Validates that <paramref name="processorNumber"/> is addressable within the affinity mask: non-negative and below
+    /// the lesser of <paramref name="processorCount"/> and <paramref name="affinityMaskWidth"/>.
+    /// </summary>
+    /// <param name="processorNumber">The zero-based processor number to validate.</param>
+    /// <param name="processorCount">The number of logical processors on the machine.</param>
+    /// <param name="affinityMaskWidth">The width, in bits, of the native affinity mask.</param>
+    /// <param name="paramName">The caller's parameter name to report in the exception.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="processorNumber"/> is not addressable.</exception>
+    /// <remarks>
+    /// Internal (rather than private) so the mask-width capping can be unit-tested with limits that do not occur on the
+    /// test machine — more than 64 logical processors, or the 32-bit-process mask width.
+    /// </remarks>
+    internal static void ValidateProcessorNumber(int processorNumber, int processorCount, int affinityMaskWidth, string paramName)
+    {
+        var maxAddressable = GetMaxAddressableProcessors(processorCount, affinityMaskWidth);
+        if (processorNumber < 0 || processorNumber >= maxAddressable)
+        {
+            throw new ArgumentOutOfRangeException(paramName,
+                                                  processorNumber,
+                                                  $"Processor number must be between 0 and {maxAddressable - 1} — the lesser of the machine's processor count ({processorCount}) and the native affinity-mask width ({affinityMaskWidth} bits).");
+        }
     }
 }

--- a/src/Common/Ploch.Common.csproj
+++ b/src/Common/Ploch.Common.csproj
@@ -48,6 +48,9 @@
         </PackageReference>
     </ItemGroup>
     <ItemGroup>
+        <InternalsVisibleTo Include="Ploch.Common.Tests" />
+    </ItemGroup>
+    <ItemGroup>
         <None Include=".\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 </Project>

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -127,9 +127,7 @@ public class ProcessExtensionsTests
         var enabledProcessors = process.GetEnabledProcessors();
 
         // Independently extract the expected processor numbers from the OS-reported mask value.
-        var affinityMask = process.ProcessorAffinity.ToInt64();
-        var maxAddressable = Math.Min(Environment.ProcessorCount, IntPtr.Size * 8);
-        var expectedProcessors = Enumerable.Range(0, maxAddressable).Where(processor => (affinityMask & (1L << processor)) != 0);
+        var expectedProcessors = GetAllowedProcessors(process);
         enabledProcessors.Should().NotBeEmpty().And.Equal(expectedProcessors);
     }
 
@@ -142,13 +140,16 @@ public class ProcessExtensionsTests
 
         try
         {
-            childProcess.SetSingleProcessorAffinity(0);
+            // The target is taken from the OS-reported mask so the test also works when CPU 0 is excluded by a cpuset.
+            var targetProcessor = GetAllowedProcessors(childProcess)[0];
 
-            childProcess.GetEnabledProcessors().Should().Equal(0);
+            childProcess.SetSingleProcessorAffinity(targetProcessor);
+
+            childProcess.GetEnabledProcessors().Should().Equal(targetProcessor);
         }
         finally
         {
-            childProcess.Kill();
+            KillAndReap(childProcess);
         }
     }
 
@@ -158,17 +159,19 @@ public class ProcessExtensionsTests
     {
         // A throwaway child process is mutated (never the test host) so parallel test collections are unaffected.
         using var childProcess = StartShortLivedChildProcess();
-        var requestedProcessors = Enumerable.Range(0, Math.Min(2, Environment.ProcessorCount)).ToArray();
 
         try
         {
+            // Targets are taken from the OS-reported mask so the test also works when CPU 0 is excluded by a cpuset.
+            var requestedProcessors = GetAllowedProcessors(childProcess).Take(2).ToArray();
+
             childProcess.SetEnabledProcessors(requestedProcessors);
 
             childProcess.GetEnabledProcessors().Should().Equal(requestedProcessors);
         }
         finally
         {
-            childProcess.Kill();
+            KillAndReap(childProcess);
         }
     }
 
@@ -182,6 +185,26 @@ public class ProcessExtensionsTests
         startInfo.UseShellExecute = false;
 
         return Process.Start(startInfo)!;
+    }
+
+    private static int[] GetAllowedProcessors(Process process)
+    {
+        // Derived from the raw OS-reported mask (not from GetEnabledProcessors) so it stays independent of the code under test.
+        var affinityMask = process.ProcessorAffinity.ToInt64();
+        var maxAddressable = Math.Min(Environment.ProcessorCount, IntPtr.Size * 8);
+
+        return Enumerable.Range(0, maxAddressable).Where(processor => (affinityMask & (1L << processor)) != 0).ToArray();
+    }
+
+    private static void KillAndReap(Process process)
+    {
+        // Kill can race with (or follow) a natural exit; the guard keeps cleanup from throwing and WaitForExit reaps the child.
+        if (!process.HasExited)
+        {
+            process.Kill();
+        }
+
+        process.WaitForExit();
     }
 
     [Theory]

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -51,6 +51,17 @@ public class ProcessExtensionsTests
     }
 
     [Fact]
+    public void SetSingleProcessorAffinity_should_throw_for_processor_number_beyond_native_mask_width()
+    {
+        var process = new Process();
+
+        // IntPtr.Size * 8 is the first processor number that cannot be represented in the native affinity mask.
+        var act = () => process.SetSingleProcessorAffinity(IntPtr.Size * 8);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().Which.ParamName.Should().Be("processorNumber");
+    }
+
+    [Fact]
     public void SetSingleProcessorAffinity_should_throw_for_null_process()
     {
         var act = () => ((Process)null!).SetSingleProcessorAffinity(0);
@@ -76,11 +87,69 @@ public class ProcessExtensionsTests
         act.Should().Throw<ArgumentException>();
     }
 
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(int.MaxValue)]
+    public void SetEnabledProcessors_should_throw_for_invalid_processor_number(int processorNumber)
+    {
+        var process = new Process();
+
+        var act = () => process.SetEnabledProcessors(processorNumber);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().Which.ParamName.Should().Be("enabledProcessorsNumbers");
+    }
+
+    [Fact]
+    public void SetEnabledProcessors_should_throw_for_processor_number_beyond_native_mask_width()
+    {
+        var process = new Process();
+
+        // IntPtr.Size * 8 is the first processor number that cannot be represented in the native affinity mask.
+        var act = () => process.SetEnabledProcessors(0, IntPtr.Size * 8);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().Which.ParamName.Should().Be("enabledProcessorsNumbers");
+    }
+
     [Fact]
     public void GetEnabledProcessors_should_throw_for_null_process()
     {
         var act = () => ((Process)null!).GetEnabledProcessors();
 
         act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData(128, 64, 64)] // Machine with >64 logical CPUs, 64-bit process: CPU 64 would wrap the shift count (64 & 63 == 0).
+    [InlineData(128, 64, 127)] // Machine with >64 logical CPUs, 64-bit process: CPU 127 would wrap to bit 63.
+    [InlineData(64, 32, 32)] // 32-bit process on a 64-CPU machine: CPU 32 would be truncated out of the 32-bit mask.
+    public void ValidateProcessorNumber_should_throw_when_processor_number_exceeds_affinity_mask_width(int processorCount, int affinityMaskWidth, int processorNumber)
+    {
+        var act = () => ProcessExtensions.ValidateProcessorNumber(processorNumber, processorCount, affinityMaskWidth, nameof(processorNumber));
+
+        act.Should()
+           .Throw<ArgumentOutOfRangeException>()
+           .Which.Should()
+           .Match<ArgumentOutOfRangeException>(exception => Equals(exception.ActualValue, processorNumber) && exception.ParamName == nameof(processorNumber));
+    }
+
+    [Theory]
+    [InlineData(128, 64, 63)] // Highest bit representable in a 64-bit mask.
+    [InlineData(64, 32, 31)] // Highest bit representable in a 32-bit mask.
+    [InlineData(4, 64, 3)] // Highest processor when the processor count is the limiting factor.
+    [InlineData(4, 64, 0)]
+    public void ValidateProcessorNumber_should_accept_processor_number_within_processor_count_and_mask_width(int processorCount, int affinityMaskWidth, int processorNumber)
+    {
+        var act = () => ProcessExtensions.ValidateProcessorNumber(processorNumber, processorCount, affinityMaskWidth, nameof(processorNumber));
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData(128, 64, 64)] // Machine with >64 logical CPUs, 64-bit process: only the first 64 CPUs are addressable.
+    [InlineData(64, 32, 32)] // 32-bit process on a 64-CPU machine: only the first 32 CPUs are addressable.
+    [InlineData(8, 64, 8)] // Typical machine: the processor count is the limiting factor.
+    public void GetMaxAddressableProcessors_should_cap_at_the_lesser_of_processor_count_and_mask_width(int processorCount, int affinityMaskWidth, int expected)
+    {
+        ProcessExtensions.GetMaxAddressableProcessors(processorCount, affinityMaskWidth).Should().Be(expected);
     }
 }

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -118,6 +118,72 @@ public class ProcessExtensionsTests
         act.Should().Throw<ArgumentNullException>();
     }
 
+    [Fact]
+    [SupportedOSPlatform(SupportedOS.Windows, SupportedOS.Linux)]
+    public void GetEnabledProcessors_should_report_the_processors_set_in_the_native_affinity_mask()
+    {
+        var process = Process.GetCurrentProcess();
+
+        var enabledProcessors = process.GetEnabledProcessors();
+
+        // Independently extract the expected processor numbers from the OS-reported mask value.
+        var affinityMask = process.ProcessorAffinity.ToInt64();
+        var maxAddressable = Math.Min(Environment.ProcessorCount, IntPtr.Size * 8);
+        var expectedProcessors = Enumerable.Range(0, maxAddressable).Where(processor => (affinityMask & (1L << processor)) != 0);
+        enabledProcessors.Should().NotBeEmpty().And.Equal(expectedProcessors);
+    }
+
+    [Fact]
+    [SupportedOSPlatform(SupportedOS.Windows, SupportedOS.Linux)]
+    public void SetSingleProcessorAffinity_should_enable_only_the_requested_processor()
+    {
+        // A throwaway child process is mutated (never the test host) so parallel test collections are unaffected.
+        using var childProcess = StartShortLivedChildProcess();
+
+        try
+        {
+            childProcess.SetSingleProcessorAffinity(0);
+
+            childProcess.GetEnabledProcessors().Should().Equal(0);
+        }
+        finally
+        {
+            childProcess.Kill();
+        }
+    }
+
+    [Fact]
+    [SupportedOSPlatform(SupportedOS.Windows, SupportedOS.Linux)]
+    public void SetEnabledProcessors_should_enable_exactly_the_requested_processors()
+    {
+        // A throwaway child process is mutated (never the test host) so parallel test collections are unaffected.
+        using var childProcess = StartShortLivedChildProcess();
+        var requestedProcessors = Enumerable.Range(0, Math.Min(2, Environment.ProcessorCount)).ToArray();
+
+        try
+        {
+            childProcess.SetEnabledProcessors(requestedProcessors);
+
+            childProcess.GetEnabledProcessors().Should().Equal(requestedProcessors);
+        }
+        finally
+        {
+            childProcess.Kill();
+        }
+    }
+
+    private static Process StartShortLivedChildProcess()
+    {
+        // Cross-platform idle child: `ping` on Windows, `sleep` on Linux. Killed by the test before it exits on its own.
+        var startInfo = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("ping", "-n 30 127.0.0.1")
+            : new ProcessStartInfo("sleep", "30");
+        startInfo.CreateNoWindow = true;
+        startInfo.UseShellExecute = false;
+
+        return Process.Start(startInfo)!;
+    }
+
     [Theory]
     [InlineData(128, 64, 64)] // Machine with >64 logical CPUs, 64-bit process: CPU 64 would wrap the shift count (64 & 63 == 0).
     [InlineData(128, 64, 127)] // Machine with >64 logical CPUs, 64-bit process: CPU 127 would wrap to bit 63.

--- a/tests/Common.Tests/Ploch.Common.Tests.csproj
+++ b/tests/Common.Tests/Ploch.Common.Tests.csproj
@@ -106,7 +106,9 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Agoda.Analyzers" />
-        <PackageReference Include="JetBrains.Annotations" />
+        <!-- Aliased so the package types do not collide (CS0433) with Ploch.Common's internal JetBrains annotations,
+             which are visible to this assembly via InternalsVisibleTo. -->
+        <PackageReference Include="JetBrains.Annotations" Aliases="JetBrainsAnnotations" />
     </ItemGroup>
     <ItemGroup>
         <Compile Remove="CoverageResults\**" />

--- a/tests/Common.Tests/Reflection/TestTypes.cs
+++ b/tests/Common.Tests/Reflection/TestTypes.cs
@@ -1,4 +1,6 @@
-using JetBrains.Annotations;
+extern alias JetBrainsAnnotations;
+
+using JetBrainsAnnotations::JetBrains.Annotations;
 using Ploch.Common.Tests.TestTypes.TestingTypes;
 
 namespace Ploch.Common.Tests.Reflection;


### PR DESCRIPTION
## **User description**
## Describe your changes

### Summary

`SetSingleProcessorAffinity`, `SetEnabledProcessors` and `GetEnabledProcessors` in `Ploch.Common.Diagnostics.ProcessExtensions` validated processor numbers only against `Environment.ProcessorCount`, ignoring the width of the native `Process.ProcessorAffinity` bitmask. Two defects (pre-existing on `master`, surfaced by review bots during #245):

- **>64 logical processors:** `1L << n` for `n >= 64` wraps the shift count (`n & 63`), silently setting the wrong affinity bit.
- **32-bit process:** `Process.ProcessorAffinity` is a 32-bit `IntPtr`, so bits 32–63 were silently truncated and `GetEnabledProcessors` mis-reported.

### Changes

- Processor numbers are now validated against the lesser of `Environment.ProcessorCount` and the native affinity-mask width (`IntPtr.Size * 8`); unaddressable numbers throw `ArgumentOutOfRangeException` with a message stating both limits (`src/Common/Diagnostics/ProcessExtensions.cs`).
- `GetEnabledProcessors` bounds its read loop the same way, so it never reports processors that cannot be represented in the mask.
- XML docs updated on all three methods to document the mask-width constraint.
- Change-log entry added (`change-log/2026-07-12-249-processextensions-affinity-mask-width.md`).

### Design decisions

- **Internal, parameter-injected validation helpers** (`GetMaxAddressableProcessors`, `ValidateProcessorNumber`) + `InternalsVisibleTo("Ploch.Common.Tests")`: the defect only manifests on >64-CPU machines or in 32-bit processes, neither of which occurs on dev/CI hardware. Injecting `processorCount`/`affinityMaskWidth` makes both defect scenarios genuinely unit-testable. Reflection-based access was rejected (Sonar S3011); a public helper was rejected (unnecessary API surface).
- **JetBrains.Annotations alias in the test project:** `InternalsVisibleTo` exposed `Ploch.Common`'s internal JetBrains annotations to the test assembly, colliding (CS0433) with the `JetBrains.Annotations` package. The package reference is now aliased (`Aliases="JetBrainsAnnotations"` + `extern alias` in `Reflection/TestTypes.cs`), keeping both deterministically resolvable.
- **Single combined cap** rather than separate errors per limit: the exception message states both limits and the effective bound, which is what a caller needs to correct the input.
- The existing `unchecked((IntPtr)mask)` casts and CA2020 pragmas are retained — still required so bit 31 wraps to the native pointer pattern in a 32-bit process instead of throwing `OverflowException`.

### Behaviour change (not breaking for supported configurations)

Calls that previously applied a silently wrong affinity mask (processor number within `ProcessorCount` but beyond the mask width) now throw `ArgumentOutOfRangeException`. Behaviour is unchanged on ≤64-CPU machines running 64-bit processes.

### Testing

- 14 new test cases in `ProcessExtensionsTests` (boundary tests at `IntPtr.Size * 8` for both setters, previously-missing out-of-range theory for `SetEnabledProcessors`, injected-limit theories covering the >64-CPU and 32-bit-mask scenarios for both internal helpers).
- Full solution: build succeeded with zero new warnings; `Ploch.Common.Tests` 841 passed (net10.0) / 808 passed (net8.0), 0 failed.
- Coverage on the new/changed code paths is complete (every branch of the validation helper is exercised).
- Note: plan/code review via Codex MCP was unavailable (account model restriction); an independent local review agent pass was used instead and its one finding (loop-bound logic not testable with injected limits) was addressed by extracting `GetMaxAddressableProcessors`.

### Review-pass follow-up (commit c495eb3)

- Added three cross-platform (Windows + Linux) tests covering the success paths of `SetSingleProcessorAffinity`, `SetEnabledProcessors` and `GetEnabledProcessors` — previously only exercised by a Windows-gated test, which left new-code coverage at 77.8% on the Linux CI runner (SonarCloud gate threshold: 80%). The setter tests mutate a throwaway child process (`ping`/`sleep`) rather than the test host so parallel xUnit collections are unaffected; the read-back test verifies against the OS-reported affinity mask bits.
- Hoisted `MaxAddressableProcessors` into a local before the `GetEnabledProcessors` loop (review suggestion from gemini-code-assist and codereviewbot-ai).
- Full suite after the change: 838 passed (net10.0) / 805 passed (net8.0), 0 failed; zero build warnings on modified files.

## Issue ticket number and link

Closes #249 — https://github.com/mrploch/ploch-common/issues/249

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? — N/A
- [ ] Will this be part of a product update? If yes, please write one phrase about this update. — Yes: processor-affinity extensions now reject processor numbers that cannot be represented in the native affinity mask instead of silently misbehaving (part of v4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Cap processor-affinity operations to the native affinity-mask width and ensure they reject unaddressable processor numbers while accurately reporting enabled processors.

Bug Fixes:
- Prevent processor-affinity APIs from silently setting or reporting incorrect affinity bits on machines with more than 64 logical processors or in 32-bit processes by capping processor numbers to the native mask width.
- Ensure GetEnabledProcessors does not report processors beyond what can be represented in the native ProcessorAffinity bitmask.

Enhancements:
- Introduce shared internal helpers to compute the maximum addressable processors and validate processor numbers against both processor count and affinity-mask width.
- Clarify XML documentation for processor-affinity extension methods to describe the mask-width constraint and resulting exceptions.

Documentation:
- Add a change-log entry documenting the processor-affinity mask-width fix and its behavioral impact.

Tests:
- Add unit tests covering mask-width boundary conditions, invalid processor numbers, and the new internal validation helpers for various processor-count and mask-width combinations.
- Adjust test project references to JetBrains.Annotations via an assembly alias to avoid type conflicts after exposing internals to tests.


___

## **CodeAnt-AI Description**
**Prevent invalid processor affinity settings on large CPU counts and 32-bit processes**

### What Changed
- Processor affinity now rejects processor numbers that cannot be represented by the current process’s native mask, instead of silently setting or reporting the wrong CPU
- `SetSingleProcessorAffinity`, `SetEnabledProcessors`, and `GetEnabledProcessors` now follow the same limit, so enabled processors are only returned when they can actually be addressed
- Tests now cover out-of-range processor numbers, mask-width edge cases, and the test project avoids a type-name clash caused by the new internal access
- Documentation and change-log notes now explain the mask-width limit and the resulting behavior change

### Impact
`✅ Fewer wrong affinity settings on servers with many CPUs`
`✅ Correct processor lists in 32-bit processes`
`✅ Clearer errors when a requested CPU cannot be addressed`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processor-affinity validation to respect both the available processor count and the system’s native affinity-mask width.
  * Invalid or unrepresentable processor numbers now consistently raise an appropriate range exception (with clearer bounds details).
  * Processor enumeration no longer reports processors that cannot be represented by the native affinity mask.
* **Tests**
  * Added coverage for processor-affinity mask-width validation scenarios.
* **Documentation**
  * Updated API documentation and added a changelog entry describing the corrected affinity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->