### PR TITLE
fix(common)!: Validate processor affinity against mask width only

### DIFF
--- a/change-log/2026-07-24-257-affinity-mask-width-only-validation.md
+++ b/change-log/2026-07-24-257-affinity-mask-width-only-validation.md
@@ -16,6 +16,10 @@ non-contiguous processor sets (for example CPUs 8–15, where `ProcessorCount` i
   rejected by the operating system when the affinity is applied (typically as `Win32Exception`).
 - `GetEnabledProcessors` reports every bit set in the native mask (bounded by the mask width alone), so
   non-contiguous affinity sets are reported correctly.
+- `SetEnabledProcessors` verifies the applied mask after setting it and throws `InvalidOperationException` if the
+  operating system did not enable every requested processor. Linux applies the intersection of the requested mask
+  and the processors available to the process (`sched_setaffinity(2)`) rather than rejecting unavailable ones, so
+  a mixed request would otherwise succeed only partially and silently.
 - XML documentation updated on all three methods to describe the new contract.
 
 ## Behaviour change (breaking)

--- a/change-log/2026-07-24-257-affinity-mask-width-only-validation.md
+++ b/change-log/2026-07-24-257-affinity-mask-width-only-validation.md
@@ -1,0 +1,27 @@
+# ProcessExtensions: validate processor affinity against the native mask width only (#257)
+
+## Summary
+
+`SetSingleProcessorAffinity`, `SetEnabledProcessors` and `GetEnabledProcessors` in
+`Ploch.Common.Diagnostics.ProcessExtensions` no longer use `Environment.ProcessorCount` as an upper bound for
+processor numbers. Since .NET 6, `Environment.ProcessorCount` is the number of processors *available to the
+process* (it already reflects the process's own affinity and CPU limits) — it is a count, not an index bound, so
+using it rejected valid processor numbers and under-reported enabled processors for processes constrained to
+non-contiguous processor sets (for example CPUs 8–15, where `ProcessorCount` is 8).
+
+## Changes
+
+- Processor numbers are now validated only against the native affinity-mask width (`IntPtr.Size * 8` — 32 in a
+  32-bit process, 64 in a 64-bit process). Processor numbers for CPUs that do not exist on the machine are
+  rejected by the operating system when the affinity is applied (typically as `Win32Exception`).
+- `GetEnabledProcessors` reports every bit set in the native mask (bounded by the mask width alone), so
+  non-contiguous affinity sets are reported correctly.
+- XML documentation updated on all three methods to describe the new contract.
+
+## Behaviour change (breaking)
+
+Calls with a processor number that is within the native mask width but greater than or equal to
+`Environment.ProcessorCount` previously threw `ArgumentOutOfRangeException` up front. They are now passed to the
+operating system: valid targets (processors the machine has, e.g. under a constrained affinity) succeed, and
+nonexistent processors surface as an OS-level error (typically `Win32Exception`) when the affinity is applied.
+Code that relied on the eager `ArgumentOutOfRangeException` for such inputs must be updated.

--- a/src/Common/Diagnostics/ProcessExtensions.cs
+++ b/src/Common/Diagnostics/ProcessExtensions.cs
@@ -12,8 +12,8 @@ public static class ProcessExtensions
 {
     /// <summary>
     /// Gets the width, in bits, of the native <see cref="Process.ProcessorAffinity"/> mask for the current process
-    /// (32 in a 32-bit process, 64 in a 64-bit process). This is the exclusive upper bound for addressable
-    /// processor numbers.
+    /// (32 in a 32-bit process, 64 in a 64-bit process). This is the exclusive upper bound for processor numbers
+    /// representable in the mask.
     /// </summary>
     private static int AffinityMaskWidth => IntPtr.Size * 8;
 
@@ -70,6 +70,11 @@ public static class ProcessExtensions
     /// Thrown if any processor number is negative, or not below the native affinity-mask width
     /// (<c>IntPtr.Size * 8</c> — 32 in a 32-bit process, 64 in a 64-bit process).
     /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the operating system did not enable every requested processor. Linux applies the intersection of the
+    /// requested mask and the processors actually available to the process (see <c>sched_setaffinity(2)</c>), so a
+    /// request mixing available and unavailable processors would otherwise succeed only partially and silently.
+    /// </exception>
     /// <remarks>
     /// Processor affinity is only supported on Windows and Linux; calling this on other platforms throws <see cref="PlatformNotSupportedException"/>.
     /// <para>
@@ -110,6 +115,11 @@ public static class ProcessExtensions
 #pragma warning disable CA2020 // Unchecked is intentional: the affinity bitmask's high bit (e.g. processor 31 on a 32-bit process) must wrap to the native pointer pattern, not throw OverflowException.
         process.ProcessorAffinity = unchecked((IntPtr)affinityMask);
 #pragma warning restore CA2020
+
+        // Linux applies the intersection of the requested mask and the CPUs actually available to the process
+        // (sched_setaffinity(2)) instead of rejecting unavailable CPUs, so a mixed request would otherwise succeed
+        // only partially and silently. Windows rejects such masks outright.
+        VerifyAppliedAffinity(affinityMask, process.ProcessorAffinity.ToInt64());
     }
 
     /// <summary>
@@ -163,6 +173,29 @@ public static class ProcessExtensions
         }
 
         return enabledProcessors;
+    }
+
+    /// <summary>
+    /// Verifies that every processor requested in <paramref name="requestedAffinityMask"/> is present in
+    /// <paramref name="appliedAffinityMask"/>, the mask the operating system reports after the affinity was applied.
+    /// </summary>
+    /// <param name="requestedAffinityMask">The affinity mask that was requested.</param>
+    /// <param name="appliedAffinityMask">The affinity mask reported by the operating system after applying.</param>
+    /// <exception cref="InvalidOperationException">Thrown if any requested processor was not enabled.</exception>
+    /// <remarks>
+    /// Internal (rather than private) so the partial-application detection can be unit-tested without a host whose
+    /// processor topology triggers it. Linux applies the intersection of the requested mask and the processors
+    /// available to the process (see <c>sched_setaffinity(2)</c>) rather than rejecting unavailable processors.
+    /// </remarks>
+    internal static void VerifyAppliedAffinity(long requestedAffinityMask, long appliedAffinityMask)
+    {
+        if ((appliedAffinityMask & requestedAffinityMask) == requestedAffinityMask)
+        {
+            return;
+        }
+
+        var missingProcessors = GetEnabledProcessors(requestedAffinityMask & ~appliedAffinityMask, AffinityMaskWidth);
+        throw new InvalidOperationException($"The operating system did not enable the requested processor(s) {string.Join(", ", missingProcessors)} — they do not exist on this machine or are not available to the process.");
     }
 
     /// <summary>

--- a/src/Common/Diagnostics/ProcessExtensions.cs
+++ b/src/Common/Diagnostics/ProcessExtensions.cs
@@ -12,15 +12,10 @@ public static class ProcessExtensions
 {
     /// <summary>
     /// Gets the width, in bits, of the native <see cref="Process.ProcessorAffinity"/> mask for the current process
-    /// (32 in a 32-bit process, 64 in a 64-bit process).
+    /// (32 in a 32-bit process, 64 in a 64-bit process). This is the exclusive upper bound for addressable
+    /// processor numbers.
     /// </summary>
     private static int AffinityMaskWidth => IntPtr.Size * 8;
-
-    /// <summary>
-    /// Gets the exclusive upper bound for addressable processor numbers: the lesser of
-    /// <see cref="Environment.ProcessorCount"/> and <see cref="AffinityMaskWidth"/>.
-    /// </summary>
-    private static int MaxAddressableProcessors => GetMaxAddressableProcessors(Environment.ProcessorCount, AffinityMaskWidth);
 
     /// <summary>
     /// Sets the processor affinity of the process to a single processor specified by <paramref name="processorNumber"/>.
@@ -29,8 +24,8 @@ public static class ProcessExtensions
     /// <param name="processorNumber">The zero-based processor number to set affinity to.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="process"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="processorNumber"/> is negative, or not below the lesser of
-    /// <see cref="Environment.ProcessorCount"/> and the native affinity-mask width (<c>IntPtr.Size * 8</c>).
+    /// Thrown if <paramref name="processorNumber"/> is negative, or not below the native affinity-mask width
+    /// (<c>IntPtr.Size * 8</c> — 32 in a 32-bit process, 64 in a 64-bit process).
     /// </exception>
     /// <remarks>
     /// Processor affinity is only supported on Windows and Linux; calling this on other platforms throws <see cref="PlatformNotSupportedException"/>.
@@ -38,6 +33,14 @@ public static class ProcessExtensions
     /// <see cref="Process.ProcessorAffinity"/> is a pointer-sized bitmask, so processors beyond the native pointer width cannot be
     /// addressed — for example processors 32 and above in a 32-bit process, or 64 and above on machines with more than
     /// 64 logical processors. Such processor numbers are rejected with <see cref="ArgumentOutOfRangeException"/>.
+    /// </para>
+    /// <para>
+    /// Processor numbers within the mask width are <b>not</b> validated against the number of processors available to the
+    /// current process: <see cref="Environment.ProcessorCount"/> is a processor <i>count</i> (which, since .NET 6, already
+    /// reflects the process's own affinity and CPU limits), not an upper bound on valid processor indices — a process
+    /// constrained to processors 8–15 may legitimately target processor 12. Requesting a processor that does not exist on
+    /// the machine is rejected by the operating system when the affinity is applied (typically as a
+    /// <see cref="System.ComponentModel.Win32Exception"/>).
     /// </para>
     /// </remarks>
 #if NET5_0_OR_GREATER
@@ -48,7 +51,7 @@ public static class ProcessExtensions
     {
         process.NotNull(nameof(process));
 
-        ValidateProcessorNumber(processorNumber, Environment.ProcessorCount, AffinityMaskWidth, nameof(processorNumber));
+        ValidateProcessorNumber(processorNumber, AffinityMaskWidth, nameof(processorNumber));
 
         var affinityMask = 1L << processorNumber;
 #pragma warning disable CA2020 // Unchecked is intentional: the affinity bitmask's high bit (e.g. processor 31 on a 32-bit process) must wrap to the native pointer pattern, not throw OverflowException.
@@ -64,8 +67,8 @@ public static class ProcessExtensions
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="process"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown if no processor numbers are specified.</exception>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if any processor number is negative, or not below the lesser of
-    /// <see cref="Environment.ProcessorCount"/> and the native affinity-mask width (<c>IntPtr.Size * 8</c>).
+    /// Thrown if any processor number is negative, or not below the native affinity-mask width
+    /// (<c>IntPtr.Size * 8</c> — 32 in a 32-bit process, 64 in a 64-bit process).
     /// </exception>
     /// <remarks>
     /// Processor affinity is only supported on Windows and Linux; calling this on other platforms throws <see cref="PlatformNotSupportedException"/>.
@@ -73,6 +76,14 @@ public static class ProcessExtensions
     /// <see cref="Process.ProcessorAffinity"/> is a pointer-sized bitmask, so processors beyond the native pointer width cannot be
     /// addressed — for example processors 32 and above in a 32-bit process, or 64 and above on machines with more than
     /// 64 logical processors. Such processor numbers are rejected with <see cref="ArgumentOutOfRangeException"/>.
+    /// </para>
+    /// <para>
+    /// Processor numbers within the mask width are <b>not</b> validated against the number of processors available to the
+    /// current process: <see cref="Environment.ProcessorCount"/> is a processor <i>count</i> (which, since .NET 6, already
+    /// reflects the process's own affinity and CPU limits), not an upper bound on valid processor indices — a process
+    /// constrained to processors 8–15 may legitimately target processor 12. Requesting a processor that does not exist on
+    /// the machine is rejected by the operating system when the affinity is applied (typically as a
+    /// <see cref="System.ComponentModel.Win32Exception"/>).
     /// </para>
     /// </remarks>
 #if NET5_0_OR_GREATER
@@ -91,7 +102,7 @@ public static class ProcessExtensions
         long affinityMask = 0;
         foreach (var number in enabledProcessorsNumbers)
         {
-            ValidateProcessorNumber(number, Environment.ProcessorCount, AffinityMaskWidth, nameof(enabledProcessorsNumbers));
+            ValidateProcessorNumber(number, AffinityMaskWidth, nameof(enabledProcessorsNumbers));
 
             affinityMask |= 1L << number;
         }
@@ -110,8 +121,11 @@ public static class ProcessExtensions
     /// <remarks>
     /// Processor affinity is only supported on Windows and Linux; calling this on other platforms throws <see cref="PlatformNotSupportedException"/>.
     /// <para>
-    /// Only processors representable in the native <see cref="Process.ProcessorAffinity"/> bitmask are reported — at most
-    /// <c>IntPtr.Size * 8</c> processors (32 in a 32-bit process, 64 in a 64-bit process).
+    /// Every bit set in the native <see cref="Process.ProcessorAffinity"/> bitmask is reported — at most
+    /// <c>IntPtr.Size * 8</c> processors (32 in a 32-bit process, 64 in a 64-bit process). The result is deliberately not
+    /// limited by <see cref="Environment.ProcessorCount"/>, which is a processor <i>count</i> rather than an index bound:
+    /// a process constrained to a non-contiguous processor set (for example processors 8–15) reports exactly those
+    /// processor numbers.
     /// </para>
     /// </remarks>
 #if NET5_0_OR_GREATER
@@ -122,12 +136,25 @@ public static class ProcessExtensions
     {
         process.NotNull(nameof(process));
 
-        // Materialise eagerly (rather than a yield iterator) so the argument guard above throws at
-        // call time instead of being deferred until the sequence is enumerated.
-        var affinityMask = process.ProcessorAffinity.ToInt64();
+        return GetEnabledProcessors(process.ProcessorAffinity.ToInt64(), AffinityMaskWidth);
+    }
+
+    /// <summary>
+    /// Extracts the zero-based processor numbers of all bits set in <paramref name="affinityMask"/>, up to
+    /// <paramref name="affinityMaskWidth"/> bits.
+    /// </summary>
+    /// <param name="affinityMask">The affinity bitmask to read.</param>
+    /// <param name="affinityMaskWidth">The width, in bits, of the native affinity mask.</param>
+    /// <returns>The processor numbers whose bits are set, in ascending order.</returns>
+    /// <remarks>
+    /// Internal (rather than private) so bit extraction can be unit-tested with masks and widths that do not occur on the
+    /// test machine — non-contiguous processor sets, or the 32-bit-process mask width. Materialises eagerly (rather than
+    /// a yield iterator) so the caller's argument guard throws at call time instead of being deferred until enumeration.
+    /// </remarks>
+    internal static IEnumerable<int> GetEnabledProcessors(long affinityMask, int affinityMaskWidth)
+    {
         var enabledProcessors = new List<int>();
-        var maxAddressableProcessors = MaxAddressableProcessors;
-        for (var i = 0; i < maxAddressableProcessors; i++)
+        for (var i = 0; i < affinityMaskWidth; i++)
         {
             if ((affinityMask & (1L << i)) != 0)
             {
@@ -139,39 +166,28 @@ public static class ProcessExtensions
     }
 
     /// <summary>
-    /// Gets the number of processors addressable in the affinity mask: the lesser of
-    /// <paramref name="processorCount"/> and <paramref name="affinityMaskWidth"/>.
-    /// </summary>
-    /// <param name="processorCount">The number of logical processors on the machine.</param>
-    /// <param name="affinityMaskWidth">The width, in bits, of the native affinity mask.</param>
-    /// <returns>The exclusive upper bound for addressable processor numbers.</returns>
-    /// <remarks>
-    /// Internal (rather than private) so the mask-width capping can be unit-tested with limits that do not occur on the
-    /// test machine — more than 64 logical processors, or the 32-bit-process mask width.
-    /// </remarks>
-    internal static int GetMaxAddressableProcessors(int processorCount, int affinityMaskWidth) => Math.Min(processorCount, affinityMaskWidth);
-
-    /// <summary>
-    /// Validates that <paramref name="processorNumber"/> is addressable within the affinity mask: non-negative and below
-    /// the lesser of <paramref name="processorCount"/> and <paramref name="affinityMaskWidth"/>.
+    /// Validates that <paramref name="processorNumber"/> is representable in the affinity mask: non-negative and below
+    /// <paramref name="affinityMaskWidth"/>.
     /// </summary>
     /// <param name="processorNumber">The zero-based processor number to validate.</param>
-    /// <param name="processorCount">The number of logical processors on the machine.</param>
     /// <param name="affinityMaskWidth">The width, in bits, of the native affinity mask.</param>
     /// <param name="paramName">The caller's parameter name to report in the exception.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="processorNumber"/> is not addressable.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="processorNumber"/> is not representable.</exception>
     /// <remarks>
     /// Internal (rather than private) so the mask-width capping can be unit-tested with limits that do not occur on the
-    /// test machine — more than 64 logical processors, or the 32-bit-process mask width.
+    /// test machine — for example the 32-bit-process mask width. <see cref="Environment.ProcessorCount"/> is deliberately
+    /// not part of the validation: it is a processor <i>count</i> (affinity-aware since .NET 6), not an index bound, so
+    /// using it would reject valid processor numbers for processes constrained to non-contiguous processor sets.
+    /// Processor numbers for CPUs that do not exist on the machine are rejected by the operating system when the
+    /// affinity is applied.
     /// </remarks>
-    internal static void ValidateProcessorNumber(int processorNumber, int processorCount, int affinityMaskWidth, string paramName)
+    internal static void ValidateProcessorNumber(int processorNumber, int affinityMaskWidth, string paramName)
     {
-        var maxAddressable = GetMaxAddressableProcessors(processorCount, affinityMaskWidth);
-        if (processorNumber < 0 || processorNumber >= maxAddressable)
+        if (processorNumber < 0 || processorNumber >= affinityMaskWidth)
         {
             throw new ArgumentOutOfRangeException(paramName,
                                                   processorNumber,
-                                                  $"Processor number must be between 0 and {maxAddressable - 1} — the lesser of the machine's processor count ({processorCount}) and the native affinity-mask width ({affinityMaskWidth} bits).");
+                                                  $"Processor number must be between 0 and {affinityMaskWidth - 1} — the width of the native processor-affinity mask ({affinityMaskWidth} bits). Processor numbers for CPUs that do not exist on this machine are rejected by the operating system when the affinity is applied.");
         }
     }
 }

--- a/src/Common/Diagnostics/ProcessExtensions.cs
+++ b/src/Common/Diagnostics/ProcessExtensions.cs
@@ -216,9 +216,12 @@ public static class ProcessExtensions
     /// <paramref name="affinityMaskWidth"/>.
     /// </summary>
     /// <param name="processorNumber">The zero-based processor number to validate.</param>
-    /// <param name="affinityMaskWidth">The width, in bits, of the native affinity mask.</param>
+    /// <param name="affinityMaskWidth">The width, in bits, of the native affinity mask. Must be between 1 and 64.</param>
     /// <param name="paramName">The caller's parameter name to report in the exception.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="processorNumber"/> is not representable.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="affinityMaskWidth"/> is not between 1 and 64, or if
+    /// <paramref name="processorNumber"/> is not representable.
+    /// </exception>
     /// <remarks>
     /// Internal (rather than private) so the mask-width capping can be unit-tested with limits that do not occur on the
     /// test machine — for example the 32-bit-process mask width. <see cref="Environment.ProcessorCount"/> is deliberately
@@ -229,6 +232,15 @@ public static class ProcessExtensions
     /// </remarks>
     internal static void ValidateProcessorNumber(int processorNumber, int affinityMaskWidth, string paramName)
     {
+        // The unsigned comparison rejects widths below 1 and above 64 in one branch (out-of-range values wrap far
+        // above 63). A relational pattern is C# 9, while the netstandard2.0 target compiles with C# 7.3.
+        if ((uint)(affinityMaskWidth - 1) > 63)
+        {
+            throw new ArgumentOutOfRangeException(nameof(affinityMaskWidth),
+                                                  affinityMaskWidth,
+                                                  "The affinity-mask width must be between 1 and 64 bits.");
+        }
+
         if (processorNumber < 0 || processorNumber >= affinityMaskWidth)
         {
             throw new ArgumentOutOfRangeException(paramName,

--- a/src/Common/Diagnostics/ProcessExtensions.cs
+++ b/src/Common/Diagnostics/ProcessExtensions.cs
@@ -154,8 +154,12 @@ public static class ProcessExtensions
     /// <paramref name="affinityMaskWidth"/> bits.
     /// </summary>
     /// <param name="affinityMask">The affinity bitmask to read.</param>
-    /// <param name="affinityMaskWidth">The width, in bits, of the native affinity mask.</param>
+    /// <param name="affinityMaskWidth">The width, in bits, of the native affinity mask. Must be between 0 and 64.</param>
     /// <returns>The processor numbers whose bits are set, in ascending order.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="affinityMaskWidth"/> is negative or greater than 64 — the <c>1L &lt;&lt; i</c> shift
+    /// would wrap for bit positions of 64 and above.
+    /// </exception>
     /// <remarks>
     /// Internal (rather than private) so bit extraction can be unit-tested with masks and widths that do not occur on the
     /// test machine — non-contiguous processor sets, or the 32-bit-process mask width. Materialises eagerly (rather than
@@ -163,6 +167,13 @@ public static class ProcessExtensions
     /// </remarks>
     internal static IEnumerable<int> GetEnabledProcessors(long affinityMask, int affinityMaskWidth)
     {
+        if (affinityMaskWidth < 0 || affinityMaskWidth > 64)
+        {
+            throw new ArgumentOutOfRangeException(nameof(affinityMaskWidth),
+                                                  affinityMaskWidth,
+                                                  "The affinity-mask width must be between 0 and 64 bits — bit positions of 64 and above cannot be represented in a 64-bit mask.");
+        }
+
         var enabledProcessors = new List<int>();
         for (var i = 0; i < affinityMaskWidth; i++)
         {

--- a/src/Common/Diagnostics/ProcessExtensions.cs
+++ b/src/Common/Diagnostics/ProcessExtensions.cs
@@ -207,7 +207,9 @@ public static class ProcessExtensions
             return;
         }
 
-        var missingProcessors = GetEnabledProcessors(requestedAffinityMask & ~appliedAffinityMask, AffinityMaskWidth);
+        // The full 64-bit width is used (rather than AffinityMaskWidth) so the error message lists every missing bit
+        // deterministically regardless of process bitness; callers already constrain requested masks to the native width.
+        var missingProcessors = GetEnabledProcessors(requestedAffinityMask & ~appliedAffinityMask, 64);
         throw new InvalidOperationException($"The operating system did not enable the requested processor(s) {string.Join(", ", missingProcessors)} — they do not exist on this machine or are not available to the process.");
     }
 

--- a/src/Common/Diagnostics/ProcessExtensions.cs
+++ b/src/Common/Diagnostics/ProcessExtensions.cs
@@ -229,8 +229,8 @@ public static class ProcessExtensions
     /// test machine — for example the 32-bit-process mask width. <see cref="Environment.ProcessorCount"/> is deliberately
     /// not part of the validation: it is a processor <i>count</i> (affinity-aware since .NET 6), not an index bound, so
     /// using it would reject valid processor numbers for processes constrained to non-contiguous processor sets.
-    /// Processor numbers for CPUs that do not exist on the machine are rejected by the operating system when the
-    /// affinity is applied.
+    /// Processor numbers for CPUs that do not exist on the machine surface when the affinity is applied — as an
+    /// operating-system error, or via <see cref="VerifyAppliedAffinity"/> where the OS applies an intersection instead.
     /// </remarks>
     internal static void ValidateProcessorNumber(int processorNumber, int affinityMaskWidth, string paramName)
     {
@@ -247,7 +247,7 @@ public static class ProcessExtensions
         {
             throw new ArgumentOutOfRangeException(paramName,
                                                   processorNumber,
-                                                  $"Processor number must be between 0 and {affinityMaskWidth - 1} — the width of the native processor-affinity mask ({affinityMaskWidth} bits). Processor numbers for CPUs that do not exist on this machine are rejected by the operating system when the affinity is applied.");
+                                                  $"Processor number must be between 0 and {affinityMaskWidth - 1} — the exclusive upper bound is the width of the native processor-affinity mask ({affinityMaskWidth} bits).");
         }
     }
 }

--- a/src/Common/Diagnostics/ProcessExtensions.cs
+++ b/src/Common/Diagnostics/ProcessExtensions.cs
@@ -167,7 +167,9 @@ public static class ProcessExtensions
     /// </remarks>
     internal static IEnumerable<int> GetEnabledProcessors(long affinityMask, int affinityMaskWidth)
     {
-        if (affinityMaskWidth < 0 || affinityMaskWidth > 64)
+        // The unsigned comparison also rejects negative widths (they wrap to values far above 64). A relational
+        // pattern (is < 0 or > 64) is not available in C# 7.3, which the netstandard2.0 target compiles with.
+        if ((uint)affinityMaskWidth > 64)
         {
             throw new ArgumentOutOfRangeException(nameof(affinityMaskWidth),
                                                   affinityMaskWidth,

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -13,14 +13,22 @@ public class ProcessExtensionsTests
     {
         var process = Process.Start("../../../../../src/TestingSupport.MockConsoleApp/bin/Debug/net10.0/Ploch.TestingSupport.MockConsoleApp.exe");
 
-        var enabledProcessors = process.GetEnabledProcessors();
-        enabledProcessors.Should().HaveCount(Environment.ProcessorCount);
+        try
+        {
+            // The target is taken from the OS-reported mask so the test also works when the allowed set does not
+            // start at CPU 0 or does not span 0..ProcessorCount-1 (e.g. a cpuset-constrained environment).
+            var allowedProcessors = GetAllowedProcessors(process);
+            process.GetEnabledProcessors().Should().Equal(allowedProcessors);
 
-        process.SetSingleProcessorAffinity(Environment.ProcessorCount - 1);
+            var targetProcessor = allowedProcessors[allowedProcessors.Length - 1];
+            process.SetSingleProcessorAffinity(targetProcessor);
 
-        enabledProcessors = process.GetEnabledProcessors();
-        enabledProcessors.Should().HaveCount(1);
-        enabledProcessors.Should().Contain(Environment.ProcessorCount - 1);
+            process.GetEnabledProcessors().Should().Equal(targetProcessor);
+        }
+        finally
+        {
+            KillAndReap(process);
+        }
     }
 
     [Theory]
@@ -218,6 +226,17 @@ public class ProcessExtensionsTests
         var act = () => ProcessExtensions.ValidateProcessorNumber(processorNumber, affinityMaskWidth, nameof(processorNumber));
 
         act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData(0)] // A zero-width mask can represent no processors at all.
+    [InlineData(65)] // The 1L << n shift would wrap for bit positions of 64 and above.
+    [InlineData(-1)]
+    public void ValidateProcessorNumber_should_throw_for_a_mask_width_that_a_64bit_mask_cannot_represent(int affinityMaskWidth)
+    {
+        var act = () => ProcessExtensions.ValidateProcessorNumber(0, affinityMaskWidth, "processorNumber");
+
+        act.Should().Throw<ArgumentOutOfRangeException>().Which.ParamName.Should().Be(nameof(affinityMaskWidth));
     }
 
     [Theory]

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -20,7 +20,7 @@ public class ProcessExtensionsTests
             var allowedProcessors = GetAllowedProcessors(process);
             process.GetEnabledProcessors().Should().Equal(allowedProcessors);
 
-            var targetProcessor = allowedProcessors[allowedProcessors.Length - 1];
+            var targetProcessor = allowedProcessors[^1];
             process.SetSingleProcessorAffinity(targetProcessor);
 
             process.GetEnabledProcessors().Should().Equal(targetProcessor);

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -11,7 +11,7 @@ public class ProcessExtensionsTests
     [SupportedOSPlatform(SupportedOS.Windows)]
     public void SetSingleProcessorAffinity_should_set_affinity_mask_for_valid_processor_number()
     {
-        var process = Process.Start("../../../../../src/TestingSupport.MockConsoleApp/bin/Debug/net10.0/Ploch.TestingSupport.MockConsoleApp.exe");
+        using var process = Process.Start("../../../../../src/TestingSupport.MockConsoleApp/bin/Debug/net10.0/Ploch.TestingSupport.MockConsoleApp.exe");
 
         try
         {

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -243,6 +243,16 @@ public class ProcessExtensionsTests
     }
 
     [Theory]
+    [InlineData(65)] // The 1L << i shift would wrap for bit positions of 64 and above.
+    [InlineData(-1)]
+    public void GetEnabledProcessors_should_throw_for_a_mask_width_that_a_64bit_mask_cannot_represent(int affinityMaskWidth)
+    {
+        var act = () => ProcessExtensions.GetEnabledProcessors(0x1L, affinityMaskWidth);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().Which.ParamName.Should().Be("affinityMaskWidth");
+    }
+
+    [Theory]
     [InlineData(0x3L, 0x3L)] // Everything requested was applied.
     [InlineData(0x1L, 0x3L)] // The OS may report more processors than requested; only the requested ones matter.
     [InlineData(0x80000000L, unchecked((long)0xFFFFFFFF80000000UL))] // 32-bit process: bit 31 applied, read back sign-extended by IntPtr.ToInt64().

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -241,4 +241,25 @@ public class ProcessExtensionsTests
         // Bit 32 is not representable in a 32-bit mask.
         ProcessExtensions.GetEnabledProcessors(0x100000000L, 32).Should().BeEmpty();
     }
+
+    [Theory]
+    [InlineData(0x3L, 0x3L)] // Everything requested was applied.
+    [InlineData(0x1L, 0x3L)] // The OS may report more processors than requested; only the requested ones matter.
+    [InlineData(0x80000000L, unchecked((long)0xFFFFFFFF80000000UL))] // 32-bit process: bit 31 applied, read back sign-extended by IntPtr.ToInt64().
+    public void VerifyAppliedAffinity_should_accept_when_every_requested_processor_was_applied(long requestedMask, long appliedMask)
+    {
+        var act = () => ProcessExtensions.VerifyAppliedAffinity(requestedMask, appliedMask);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData(unchecked((long)0x8000000000000001UL), 0x1L, "63")] // Linux silently drops the unavailable CPU 63 (sched_setaffinity intersects).
+    [InlineData(0x3L, 0x1L, "1")]
+    public void VerifyAppliedAffinity_should_throw_when_a_requested_processor_was_not_applied(long requestedMask, long appliedMask, string expectedMissingProcessor)
+    {
+        var act = () => ProcessExtensions.VerifyAppliedAffinity(requestedMask, appliedMask);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage($"*{expectedMissingProcessor}*");
+    }
 }

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -206,6 +206,7 @@ public class ProcessExtensionsTests
     [InlineData(64, 64)] // 64-bit process: CPU 64 would wrap the shift count (64 & 63 == 0).
     [InlineData(64, 127)] // 64-bit process: CPU 127 would wrap to bit 63.
     [InlineData(32, 32)] // 32-bit process: CPU 32 would be truncated out of the 32-bit mask.
+    [InlineData(1, 1)] // A single-bit mask can only represent processor 0.
     [InlineData(64, -1)] // Negative processor numbers are never valid.
     public void ValidateProcessorNumber_should_throw_when_processor_number_is_not_representable_in_the_mask(int affinityMaskWidth, int processorNumber)
     {
@@ -221,6 +222,7 @@ public class ProcessExtensionsTests
     [InlineData(64, 63)] // Highest bit representable in a 64-bit mask.
     [InlineData(32, 31)] // Highest bit representable in a 32-bit mask.
     [InlineData(64, 0)]
+    [InlineData(1, 0)] // A single-bit mask can only represent processor 0.
     public void ValidateProcessorNumber_should_accept_processor_number_within_the_mask_width(int affinityMaskWidth, int processorNumber)
     {
         var act = () => ProcessExtensions.ValidateProcessorNumber(processorNumber, affinityMaskWidth, nameof(processorNumber));
@@ -252,6 +254,13 @@ public class ProcessExtensionsTests
     public void GetEnabledProcessors_should_return_no_processors_for_an_empty_mask()
     {
         ProcessExtensions.GetEnabledProcessors(0L, 64).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetEnabledProcessors_should_return_no_processors_for_a_zero_width_mask()
+    {
+        // A zero-width mask can represent no processors, no matter which bits are set.
+        ProcessExtensions.GetEnabledProcessors(unchecked((long)0xFFFFFFFFFFFFFFFFUL), 0).Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -249,7 +249,7 @@ public class ProcessExtensionsTests
     {
         var act = () => ProcessExtensions.GetEnabledProcessors(0x1L, affinityMaskWidth);
 
-        act.Should().Throw<ArgumentOutOfRangeException>().Which.ParamName.Should().Be("affinityMaskWidth");
+        act.Should().Throw<ArgumentOutOfRangeException>().Which.ParamName.Should().Be(nameof(affinityMaskWidth));
     }
 
     [Theory]

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -39,18 +39,6 @@ public class ProcessExtensionsTests
     }
 
     [Fact]
-    public void SetSingleProcessorAffinity_should_throw_for_processor_number_exceeding_system_processor_count()
-    {
-        var process = new Process();
-
-        // Act
-        var act = () => process.SetSingleProcessorAffinity(Environment.ProcessorCount);
-
-        // Assert
-        act.Should().Throw<ArgumentOutOfRangeException>();
-    }
-
-    [Fact]
     public void SetSingleProcessorAffinity_should_throw_for_processor_number_beyond_native_mask_width()
     {
         var process = new Process();
@@ -191,9 +179,8 @@ public class ProcessExtensionsTests
     {
         // Derived from the raw OS-reported mask (not from GetEnabledProcessors) so it stays independent of the code under test.
         var affinityMask = process.ProcessorAffinity.ToInt64();
-        var maxAddressable = Math.Min(Environment.ProcessorCount, IntPtr.Size * 8);
 
-        return Enumerable.Range(0, maxAddressable).Where(processor => (affinityMask & (1L << processor)) != 0).ToArray();
+        return Enumerable.Range(0, IntPtr.Size * 8).Where(processor => (affinityMask & (1L << processor)) != 0).ToArray();
     }
 
     private static void KillAndReap(Process process)
@@ -208,12 +195,13 @@ public class ProcessExtensionsTests
     }
 
     [Theory]
-    [InlineData(128, 64, 64)] // Machine with >64 logical CPUs, 64-bit process: CPU 64 would wrap the shift count (64 & 63 == 0).
-    [InlineData(128, 64, 127)] // Machine with >64 logical CPUs, 64-bit process: CPU 127 would wrap to bit 63.
-    [InlineData(64, 32, 32)] // 32-bit process on a 64-CPU machine: CPU 32 would be truncated out of the 32-bit mask.
-    public void ValidateProcessorNumber_should_throw_when_processor_number_exceeds_affinity_mask_width(int processorCount, int affinityMaskWidth, int processorNumber)
+    [InlineData(64, 64)] // 64-bit process: CPU 64 would wrap the shift count (64 & 63 == 0).
+    [InlineData(64, 127)] // 64-bit process: CPU 127 would wrap to bit 63.
+    [InlineData(32, 32)] // 32-bit process: CPU 32 would be truncated out of the 32-bit mask.
+    [InlineData(64, -1)] // Negative processor numbers are never valid.
+    public void ValidateProcessorNumber_should_throw_when_processor_number_is_not_representable_in_the_mask(int affinityMaskWidth, int processorNumber)
     {
-        var act = () => ProcessExtensions.ValidateProcessorNumber(processorNumber, processorCount, affinityMaskWidth, nameof(processorNumber));
+        var act = () => ProcessExtensions.ValidateProcessorNumber(processorNumber, affinityMaskWidth, nameof(processorNumber));
 
         act.Should()
            .Throw<ArgumentOutOfRangeException>()
@@ -222,23 +210,24 @@ public class ProcessExtensionsTests
     }
 
     [Theory]
-    [InlineData(128, 64, 63)] // Highest bit representable in a 64-bit mask.
-    [InlineData(64, 32, 31)] // Highest bit representable in a 32-bit mask.
-    [InlineData(4, 64, 3)] // Highest processor when the processor count is the limiting factor.
-    [InlineData(4, 64, 0)]
-    public void ValidateProcessorNumber_should_accept_processor_number_within_processor_count_and_mask_width(int processorCount, int affinityMaskWidth, int processorNumber)
+    [InlineData(64, 63)] // Highest bit representable in a 64-bit mask.
+    [InlineData(32, 31)] // Highest bit representable in a 32-bit mask.
+    [InlineData(64, 0)]
+    public void ValidateProcessorNumber_should_accept_processor_number_within_the_mask_width(int affinityMaskWidth, int processorNumber)
     {
-        var act = () => ProcessExtensions.ValidateProcessorNumber(processorNumber, processorCount, affinityMaskWidth, nameof(processorNumber));
+        var act = () => ProcessExtensions.ValidateProcessorNumber(processorNumber, affinityMaskWidth, nameof(processorNumber));
 
         act.Should().NotThrow();
     }
 
     [Theory]
-    [InlineData(128, 64, 64)] // Machine with >64 logical CPUs, 64-bit process: only the first 64 CPUs are addressable.
-    [InlineData(64, 32, 32)] // 32-bit process on a 64-CPU machine: only the first 32 CPUs are addressable.
-    [InlineData(8, 64, 8)] // Typical machine: the processor count is the limiting factor.
-    public void GetMaxAddressableProcessors_should_cap_at_the_lesser_of_processor_count_and_mask_width(int processorCount, int affinityMaskWidth, int expected)
+    [InlineData(0xFF00L, 64, new[] { 8, 9, 10, 11, 12, 13, 14, 15 })] // Non-contiguous set: processors 8-15 (e.g. a cpuset-constrained process where ProcessorCount == 8).
+    [InlineData(0x1L, 64, new[] { 0 })]
+    [InlineData(0x0L, 64, new int[0])] // No bits set.
+    [InlineData(0x100000000L, 32, new int[0])] // Bit 32 is not representable in a 32-bit mask.
+    [InlineData(unchecked((long)0x8000000000000001UL), 64, new[] { 0, 63 })] // Highest and lowest bits of a 64-bit mask.
+    public void GetEnabledProcessors_should_extract_all_set_bits_within_the_mask_width(long affinityMask, int affinityMaskWidth, int[] expectedProcessors)
     {
-        ProcessExtensions.GetMaxAddressableProcessors(processorCount, affinityMaskWidth).Should().Be(expected);
+        ProcessExtensions.GetEnabledProcessors(affinityMask, affinityMaskWidth).Should().Equal(expectedProcessors);
     }
 }

--- a/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
+++ b/tests/Common.Tests/Diagnostics/ProcessExtensionsTests.cs
@@ -223,11 +223,22 @@ public class ProcessExtensionsTests
     [Theory]
     [InlineData(0xFF00L, 64, new[] { 8, 9, 10, 11, 12, 13, 14, 15 })] // Non-contiguous set: processors 8-15 (e.g. a cpuset-constrained process where ProcessorCount == 8).
     [InlineData(0x1L, 64, new[] { 0 })]
-    [InlineData(0x0L, 64, new int[0])] // No bits set.
-    [InlineData(0x100000000L, 32, new int[0])] // Bit 32 is not representable in a 32-bit mask.
     [InlineData(unchecked((long)0x8000000000000001UL), 64, new[] { 0, 63 })] // Highest and lowest bits of a 64-bit mask.
     public void GetEnabledProcessors_should_extract_all_set_bits_within_the_mask_width(long affinityMask, int affinityMaskWidth, int[] expectedProcessors)
     {
         ProcessExtensions.GetEnabledProcessors(affinityMask, affinityMaskWidth).Should().Equal(expectedProcessors);
+    }
+
+    [Fact]
+    public void GetEnabledProcessors_should_return_no_processors_for_an_empty_mask()
+    {
+        ProcessExtensions.GetEnabledProcessors(0L, 64).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetEnabledProcessors_should_ignore_bits_beyond_the_mask_width()
+    {
+        // Bit 32 is not representable in a 32-bit mask.
+        ProcessExtensions.GetEnabledProcessors(0x100000000L, 32).Should().BeEmpty();
     }
 }


### PR DESCRIPTION
## Describe your changes

### Summary

Implements #257: `Environment.ProcessorCount` is no longer used as an upper bound for processor numbers in `Ploch.Common.Diagnostics.ProcessExtensions`. Since .NET 6, `ProcessorCount` is the number of processors *available to the process* (it already reflects the process's own affinity and CPU limits) — it is a count, not an index bound. Using it as an affinity-bit index cap rejected valid processor numbers and under-reported enabled processors for processes constrained to non-contiguous processor sets (e.g. CPUs 8–15, where `ProcessorCount == 8`).

### Changes

- `ValidateProcessorNumber` now validates only against the native affinity-mask width (`IntPtr.Size * 8` — 32 in a 32-bit process, 64 in a 64-bit process); the `processorCount` parameter is removed (`src/Common/Diagnostics/ProcessExtensions.cs`).
- `GetEnabledProcessors` reports every bit set in the native mask via a new internal, unit-testable core `GetEnabledProcessors(long affinityMask, int affinityMaskWidth)`, so non-contiguous affinity sets are reported correctly.
- `MaxAddressableProcessors` and `GetMaxAddressableProcessors` (internal helpers introduced in #256) are removed — the mask width is the single bound.
- XML documentation updated on all three public methods: processor numbers within the mask width are not validated against `ProcessorCount`; CPUs that do not exist on the machine are rejected by the operating system when the affinity is applied (typically `Win32Exception`).
- Change-log entry added (`change-log/2026-07-24-257-affinity-mask-width-only-validation.md`).

### Design decisions

- **Mask width as the sole eager bound.** The library validates what it can know reliably (representability in the native mask); actual CPU existence is the OS's call. Machine-wide logical CPU count is not reliably obtainable cross-platform without P/Invoke, and `ProcessorCount` is affinity-aware, so any eager count-based check would be wrong for constrained processes.
- **Internal `GetEnabledProcessors(long, int)` core** keeps the bit-extraction logic unit-testable for masks/widths that do not occur on the test machine (non-contiguous sets, 32-bit width), consistent with the `InternalsVisibleTo` approach from #256.

### Behaviour change (breaking)

Calls with a processor number within the native mask width but ≥ `Environment.ProcessorCount` previously threw `ArgumentOutOfRangeException` eagerly. They are now passed to the operating system: valid targets (processors the machine has, under a constrained affinity) succeed, and nonexistent processors surface as an OS-level error (typically `Win32Exception`) when the affinity is applied.

### Testing

- `ValidateProcessorNumber` theories rewritten for the new signature (throw: width 64/32 boundaries, 127, −1; accept: 63@64, 31@32, 0).
- New mask-extraction theories on the internal core: non-contiguous set `0xFF00 → [8..15]`, single/zero-bit masks, bit 32 excluded at width 32, and both 64-bit extremes (`[0, 63]`).
- The obsolete `ProcessorCount`-cap test is removed with the contract; existing child-process round-trip tests are unchanged.
- Full solution builds with zero new warnings; `Ploch.Common.Tests`: 852 passed (net10.0) / 819 passed (net8.0), 0 failed.

### Reviews performed before push

- Gemini code review: **APPROVED_WITH_NOTES** (notes: document the contract change — done in XML docs + change-log; platform caveats — already documented).
- Independent local review agent (substituting the Codex MCP, which rejects all models on this account): **APPROVED** — verified no residual `ProcessorCount` capping, no coverage holes, docs and change-log accuracy.

### Review-driven additions

- **Applied-affinity verification (commit 40777fc):** `SetEnabledProcessors` now reads the OS-reported mask back after applying it and throws `InvalidOperationException` listing any requested processors that were not enabled. Linux applies the *intersection* of the requested mask and the processors available to the process (`sched_setaffinity(2)`) rather than rejecting unavailable ones, so a mixed request (e.g. `{0, 63}` on a small host) would otherwise succeed only partially and silently (chatgpt-codex-connector P2 finding). `SetSingleProcessorAffinity` needs no verification — a single-CPU mask either applies fully or produces an empty intersection, which the OS rejects. The check is implemented as an internal, unit-tested core (`VerifyAppliedAffinity`), including a 32-bit sign-extension case.
- **Doc wording:** `AffinityMaskWidth` XML doc now says "representable" instead of "addressable" (Copilot suggestion).
- **DeepSource CS-P1009 (commit e281c0e):** empty-array `[InlineData]` rows replaced with dedicated `BeEmpty()` facts (`Array.Empty<int>()` is not usable in attribute arguments).

- **Later review rounds (commits 46f9bef → 6c594b4):** DeepSource CS-R1019 (index-from-end); `ValidateProcessorNumber` now guards its own mask-width parameter (1–64); the legacy Windows-only round-trip test picks its target from the child's OS-reported mask, and kills/reaps + disposes the child; `VerifyAppliedAffinity` lists missing bits over the full 64-bit width so its message is bitness-independent (CodeRabbit); Sourcery's zero-width-mask and single-bit-mask boundary tests added; exception message reworded to stay focused on representability (Copilot). One Copilot thread (null-check on `Process.Start(string)`) was resolved as a false positive with compiler evidence — that overload is annotated non-nullable.

## Issue ticket number and link

Closes #257 — https://github.com/mrploch/ploch-common/issues/257

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? — N/A
- [ ] Will this be part of a product update? If yes, please write one phrase about this update. — Yes: processor-affinity extensions now support non-contiguous constrained affinities; validation is against the native mask width, with nonexistent CPUs rejected by the OS (part of v4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate processor affinity solely against the native mask width and ensure applied affinity matches requested processors, improving correctness for constrained and non-contiguous CPU sets.

New Features:
- Add verification that SetEnabledProcessors successfully enables all requested processors and throw InvalidOperationException when the OS applies only a subset.

Bug Fixes:
- Stop using Environment.ProcessorCount as an upper bound for processor indices so affinity operations work correctly for processes constrained to non-contiguous or higher-indexed CPUs.

Enhancements:
- Report all enabled processors directly from the native affinity mask via a reusable GetEnabledProcessors core that is independent of Environment.ProcessorCount.
- Tighten processor-number validation around affinity-mask representability and make mask-width constraints explicit and OS-driven.

Documentation:
- Update XML documentation and add a change-log entry to describe the new affinity validation contract and behavior across platforms.

Tests:
- Expand and restructure ProcessExtensions tests to cover mask-width-only validation, non-contiguous affinity masks, applied-affinity verification, and edge cases such as 32-bit mask widths and invalid mask sizes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Processor affinity validation now uses the supported affinity-mask width rather than the system’s processor count.
  - Requests for unavailable processors may now return operating-system errors instead of immediate validation errors.

- **Bug Fixes**
  - Affinity queries now correctly report non-contiguous enabled processors.
  - Affinity updates detect and report when requested processors were not applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
