### PR TITLE
chore(webui): Enable NuGet packaging for Ploch.Common.WebUI

### DIFF
--- a/change-log/2026-07-25-250-webui-package-enabled.md
+++ b/change-log/2026-07-25-250-webui-package-enabled.md
@@ -6,9 +6,10 @@
 
 - `Ploch.Common.WebUI` is now published as a NuGet package. The project always had packaging
   intent (a package README), but `Microsoft.NET.Sdk.Web` defaults `IsPackable` to `false`,
-  which silently prevented the package from being produced. `IsPackable` is now explicitly
-  enabled, so the package (containing `AppPage`, `SelectListHelper`, and related Razor/MVC
-  page utilities) ships alongside the other `Ploch.*` packages from this release onwards.
+  which prevented the package from being produced (surfacing only as a pack warning on every
+  build). `IsPackable` is now explicitly enabled, so the package (containing `AppPage`,
+  `SelectListHelper`, and related Razor/MVC page utilities) ships alongside the other
+  `Ploch.*` packages from this release onwards.
 
 ## Fixed
 

--- a/change-log/2026-07-25-250-webui-package-enabled.md
+++ b/change-log/2026-07-25-250-webui-package-enabled.md
@@ -1,0 +1,16 @@
+# Ploch.Common.WebUI now ships as a NuGet package
+
+**Issue:** [#250](https://github.com/mrploch/ploch-common/issues/250)
+
+## New
+
+- `Ploch.Common.WebUI` is now published as a NuGet package. The project always had packaging
+  intent (a package README), but `Microsoft.NET.Sdk.Web` defaults `IsPackable` to `false`,
+  which silently prevented the package from being produced. `IsPackable` is now explicitly
+  enabled, so the package (containing `AppPage`, `SelectListHelper`, and related Razor/MVC
+  page utilities) ships alongside the other `Ploch.*` packages from this release onwards.
+
+## Fixed
+
+- The `NuGet.Build.Tasks.Pack` warning ("This project cannot be packaged because packaging
+  has been disabled") emitted on every build of the solution is resolved.

--- a/src/Common.WebUI/Ploch.Common.WebUI.csproj
+++ b/src/Common.WebUI/Ploch.Common.WebUI.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Microsoft.NET.Sdk.Web defaults IsPackable to false; this project ships as a NuGet package (see #250). -->
+    <IsPackable>true</IsPackable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <OutputType>Library</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Implements #250 — resolves the `IsPackable` conflict for `Ploch.Common.WebUI` by deciding **yes, the project ships as a NuGet package** (the decision requested by the issue, confirmed with the repo owner as part of the v4.0 pre-release batch).

## Changes

- Added `<IsPackable>true</IsPackable>` to `Ploch.Common.WebUI.csproj` (with a comment explaining the `Microsoft.NET.Sdk.Web` default it overrides).
- Added a change-log entry — a new package shipping is a user-visible change for the v4.0 release notes.

## Design Decisions

- **Pack rather than disable** — the project has had packaging intent all along (`PackageReadmeFile`, README packed) and contains shipped utility code (`AppPage`, `SelectListHelper` — the latter just bug-fixed in #248/PR #255). The docs (`docs/libraries/common-webui.md`) already instruct `dotnet add package Ploch.Common.WebUI`; this makes that instruction true.
- Package metadata verified by unpacking the produced `.nupkg`: id, authors, Apache-2.0 licence, README, SourceLink repository commit, dependency group and `Microsoft.AspNetCore.App` framework reference all render correctly.

## Testing

- `Ploch.Common.WebUI.4.0.9-prerelease.*.nupkg` produced on build; nuspec inspected and correct.
- Full solution build: **zero warnings** — first fully-clean build (this was the last remaining warning).
- Full test suite: all 15 test assemblies pass, 0 failures.

## Related

Closes #250

## Summary by Sourcery

Enable NuGet packaging for Ploch.Common.WebUI and document the change in the release change-log.

New Features:
- Publish Ploch.Common.WebUI as a NuGet package alongside other Ploch.* libraries.

Bug Fixes:
- Resolve the NuGet packaging warning by explicitly enabling IsPackable for the WebUI project.

Documentation:
- Add a change-log entry describing that Ploch.Common.WebUI now ships as a NuGet package.