### PR TITLE
perf(common): Optimise TakeRandom with a partial Fisher-Yates shuffle

### DIFF
--- a/change-log/2026-07-25-252-takerandom-fisher-yates.md
+++ b/change-log/2026-07-25-252-takerandom-fisher-yates.md
@@ -1,0 +1,12 @@
+# TakeRandom optimised with a partial Fisher-Yates shuffle
+
+**Issue:** [#252](https://github.com/mrploch/ploch-common/issues/252)
+
+## Changed
+
+- `EnumerableExtensions.TakeRandom<T>` now selects items with a partial Fisher-Yates shuffle
+  over an index array instead of repeated `List<T>.RemoveAt` calls, improving complexity from
+  O(count × n) to O(n) setup + O(count) selection. Uniform selection probability and
+  no-duplicate-picks behaviour are unchanged.
+- Behaviour for a zero or negative `count` is now explicitly documented: an empty sequence is
+  returned, matching `Enumerable.Take` semantics (deliberate decision — no breaking change).

--- a/change-log/2026-07-25-252-takerandom-fisher-yates.md
+++ b/change-log/2026-07-25-252-takerandom-fisher-yates.md
@@ -5,8 +5,10 @@
 ## Changed
 
 - `EnumerableExtensions.TakeRandom<T>` now selects items with a partial Fisher-Yates shuffle
-  over an index array instead of repeated `List<T>.RemoveAt` calls, improving complexity from
-  O(count × n) to O(n) setup + O(count) selection. Uniform selection probability and
-  no-duplicate-picks behaviour are unchanged.
+  performed directly on a private copy of the source list instead of repeated
+  `List<T>.RemoveAt` calls, improving complexity from O(count × n) to O(n) setup +
+  O(count) selection. A full-size draw returns the shuffled copy without an extra
+  prefix copy. Uniform selection probability and no-duplicate-picks behaviour are
+  unchanged.
 - Behaviour for a zero or negative `count` is now explicitly documented: an empty sequence is
   returned, matching `Enumerable.Take` semantics (deliberate decision — no breaking change).

--- a/src/Common/Collections/EnumerableExtensions.cs
+++ b/src/Common/Collections/EnumerableExtensions.cs
@@ -188,11 +188,14 @@ public static class EnumerableExtensions
     /// </param>
     /// <typeparam name="TValue">The enumerable value type.</typeparam>
     /// <returns>The random items from the source enumerable.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="source" /> is <see langword="null" />.</exception>
     [SuppressMessage("Security",
                      "CA5394:Do not use insecure randomness",
                      Justification = "Selecting random items from a collection is not a security-sensitive operation; cryptographic randomness is unnecessary and would degrade performance.")]
     public static IEnumerable<TValue> TakeRandom<TValue>(this IEnumerable<TValue> source, int count)
     {
+        source.NotNull(nameof(source));
+
         if (count <= 0)
         {
             return [];

--- a/src/Common/Collections/EnumerableExtensions.cs
+++ b/src/Common/Collections/EnumerableExtensions.cs
@@ -211,7 +211,8 @@ public static class EnumerableExtensions
             (list[i], list[swapIndex]) = (list[swapIndex], list[i]);
         }
 
-        return list.GetRange(0, count);
+        // The list is a private copy, so a full-size draw can return it directly without another copy.
+        return count == list.Count ? list : list.GetRange(0, count);
     }
 
     /// <summary>

--- a/src/Common/Collections/EnumerableExtensions.cs
+++ b/src/Common/Collections/EnumerableExtensions.cs
@@ -176,8 +176,15 @@ public static class EnumerableExtensions
     /// <summary>
     ///     Takes random <paramref name="count" /> amount of items from the <paramref name="source" /> enumerable.
     /// </summary>
+    /// <remarks>
+    ///     Selection is performed with a partial Fisher-Yates shuffle over an index array, giving O(n) setup and
+    ///     O(<paramref name="count" />) selection with uniform selection probability and no duplicate picks.
+    /// </remarks>
     /// <param name="source">The source enumerable.</param>
-    /// <param name="count">The number of values to take.</param>
+    /// <param name="count">
+    ///     The number of values to take. When greater than the source size, all items are returned; when zero or
+    ///     negative, an empty sequence is returned (matching <see cref="Enumerable.Take{TSource}(IEnumerable{TSource}, int)" /> semantics).
+    /// </param>
     /// <typeparam name="TValue">The enumerable value type.</typeparam>
     /// <returns>The random items from the source enumerable.</returns>
     [SuppressMessage("Security",
@@ -187,23 +194,28 @@ public static class EnumerableExtensions
     {
         var list = source.ToList();
 
-        var result = new List<TValue>();
-
-        var indexes = new List<int>(list.Count);
-        for (var i = 0; i < list.Count; i++)
+        if (count > list.Count)
         {
-            indexes.Add(i);
+            count = list.Count;
         }
 
-        count = count > list.Count ? list.Count : count;
+        if (count <= 0)
+        {
+            return [];
+        }
 
+        var indexes = new int[list.Count];
+        for (var i = 0; i < indexes.Length; i++)
+        {
+            indexes[i] = i;
+        }
+
+        var result = new List<TValue>(count);
         for (var i = 0; i < count; i++)
         {
-            var indexesItemNum = ThreadSafeRandom.Shared.Next(indexes.Count);
-            var itemIndex = indexes[indexesItemNum];
-
-            result.Add(list[itemIndex]);
-            indexes.RemoveAt(indexesItemNum);
+            var swapIndex = ThreadSafeRandom.Shared.Next(i, indexes.Length);
+            (indexes[i], indexes[swapIndex]) = (indexes[swapIndex], indexes[i]);
+            result.Add(list[indexes[i]]);
         }
 
         return result;

--- a/src/Common/Collections/EnumerableExtensions.cs
+++ b/src/Common/Collections/EnumerableExtensions.cs
@@ -177,8 +177,9 @@ public static class EnumerableExtensions
     ///     Takes random <paramref name="count" /> amount of items from the <paramref name="source" /> enumerable.
     /// </summary>
     /// <remarks>
-    ///     Selection is performed with a partial Fisher-Yates shuffle over an index array, giving O(n) setup and
-    ///     O(<paramref name="count" />) selection with uniform selection probability and no duplicate picks.
+    ///     Selection is performed with a partial Fisher-Yates shuffle over a copy of the source, giving O(n) setup and
+    ///     O(<paramref name="count" />) selection with uniform selection probability and no duplicate picks. A
+    ///     non-positive <paramref name="count" /> returns without enumerating <paramref name="source" />.
     /// </remarks>
     /// <param name="source">The source enumerable.</param>
     /// <param name="count">
@@ -192,6 +193,11 @@ public static class EnumerableExtensions
                      Justification = "Selecting random items from a collection is not a security-sensitive operation; cryptographic randomness is unnecessary and would degrade performance.")]
     public static IEnumerable<TValue> TakeRandom<TValue>(this IEnumerable<TValue> source, int count)
     {
+        if (count <= 0)
+        {
+            return [];
+        }
+
         var list = source.ToList();
 
         if (count > list.Count)
@@ -199,26 +205,13 @@ public static class EnumerableExtensions
             count = list.Count;
         }
 
-        if (count <= 0)
-        {
-            return [];
-        }
-
-        var indexes = new int[list.Count];
-        for (var i = 0; i < indexes.Length; i++)
-        {
-            indexes[i] = i;
-        }
-
-        var result = new List<TValue>(count);
         for (var i = 0; i < count; i++)
         {
-            var swapIndex = ThreadSafeRandom.Shared.Next(i, indexes.Length);
-            (indexes[i], indexes[swapIndex]) = (indexes[swapIndex], indexes[i]);
-            result.Add(list[indexes[i]]);
+            var swapIndex = ThreadSafeRandom.Shared.Next(i, list.Count);
+            (list[i], list[swapIndex]) = (list[swapIndex], list[i]);
         }
 
-        return result;
+        return list.GetRange(0, count);
     }
 
     /// <summary>

--- a/tests/Common.Tests/Collections/EnumerableExtensionsTests.cs
+++ b/tests/Common.Tests/Collections/EnumerableExtensionsTests.cs
@@ -171,6 +171,20 @@ public class EnumerableExtensionsTests(ITestOutputHelper output)
         result.Should().BeEmpty();
     }
 
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(5)]
+    public void TakeRandom_should_throw_ArgumentNullException_when_source_is_null(int count)
+    {
+        IEnumerable<int> sourceList = null!;
+
+        var act = () => sourceList.TakeRandom(count);
+
+        // Null validation must run before the non-positive-count short-circuit.
+        act.Should().Throw<ArgumentNullException>().WithParameterName("source");
+    }
+
     [Fact]
     public void TakeRandom_should_not_select_the_same_item_twice()
     {

--- a/tests/Common.Tests/Collections/EnumerableExtensionsTests.cs
+++ b/tests/Common.Tests/Collections/EnumerableExtensionsTests.cs
@@ -161,6 +161,34 @@ public class EnumerableExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void TakeRandom_should_return_empty_sequence_when_count_is_negative()
+    {
+        var sourceList = new[] { 1, 2, 3 };
+
+        var result = sourceList.TakeRandom(-5);
+
+        // Matches Enumerable.Take semantics - a negative count yields an empty sequence rather than throwing.
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TakeRandom_should_not_select_the_same_item_twice()
+    {
+        var sourceList = new List<int>();
+        for (var i = 0; i < 50; i++)
+        {
+            sourceList.Add(i);
+        }
+
+        for (var i = 0; i < 20; i++)
+        {
+            var result = sourceList.TakeRandom(50).ToList();
+
+            result.Should().OnlyHaveUniqueItems().And.BeEquivalentTo(sourceList);
+        }
+    }
+
+    [Fact]
     public void JoinWithFinalSeparator_should_use_final_separator_for_last_item()
     {
         var strings = new Fixture().CreateMany<string>(20);


### PR DESCRIPTION
## **User description**
## Summary

Implements #252 — replaces `TakeRandom`'s removal-based selection with a partial Fisher-Yates shuffle, and settles the open semantics question from the issue.

## Changes

- `EnumerableExtensions.TakeRandom<T>`: selection now runs a partial Fisher-Yates shuffle directly on a private copy of the source list (swap the chosen element into the front of the active range) — O(n) setup + O(count) selection, replacing the previous O(count × n) `List<T>.RemoveAt` approach. A full-size draw returns the shuffled copy without an extra prefix copy. Uniform selection probability and no-duplicate-picks behaviour preserved.
- XML docs expanded: the `<remarks>` describe the algorithm, and the `count` parameter now documents the clamping (count > size → all items) and zero/negative behaviour.
- Tests: added `TakeRandom_should_return_empty_sequence_when_count_is_negative` (pins the semantics decision), `TakeRandom_should_not_select_the_same_item_twice` (20 × full-size draws must each be a permutation of the source) and `TakeRandom_should_throw_ArgumentNullException_when_source_is_null` (three counts; pins eager validation). The existing reachability (#246 regression), clamping, and edge-case tests guard the refactor.
- `source` is validated (`NotNull`) before the non-positive-count short-circuit, so a null source always throws `ArgumentNullException` — matching `Enumerable.Take`'s eager validation and the pre-optimisation behaviour (review finding).
- Change-log entry added.

## Design Decisions

- **Negative `count` keeps LINQ `Take` semantics** (empty sequence, no throw) — the deliberate decision requested by the issue, confirmed with the repo owner. Consistency with the BCL beats a stricter contract here, and it avoids a breaking change on the eve of v4.0. The behaviour is now documented and pinned by a test rather than incidental.
- Front-swap partial Fisher-Yates (swap chosen into position `i`, draw from `[i, n)`) rather than the swap-to-end variant — identical properties, and the drawn prefix directly yields the result order.
- `OrderBy(_ => random.Next())` was rejected per the issue's own note (O(n log n), unstable-key sort-contract risk).

## Testing

- 45/45 `EnumerableExtensionsTests` pass on net8.0 and net10.0.
- Full solution test suite: zero failures across all 15 assemblies.
- Build: zero new warnings (the only warning on this branch is the pre-existing WebUI IsPackable one, fixed by #261 in this batch).

## Related

Closes #252

## Summary by Sourcery

Optimise EnumerableExtensions.TakeRandom to use a partial Fisher–Yates shuffle with clarified semantics for count and updated tests and change-log entry.

Bug Fixes:
- Define and enforce negative and zero count semantics for TakeRandom to return an empty sequence, matching LINQ Take behavior.

Enhancements:
- Replace removal-based random selection in TakeRandom with a partial Fisher–Yates shuffle over an index array for better performance and preserved uniformity and uniqueness.
- Expand XML documentation for TakeRandom to describe the algorithm and document clamping and count behavior.

Documentation:
- Add a change-log entry documenting the TakeRandom optimization and its clarified count behavior.

Tests:
- Add tests covering negative count returning an empty sequence and ensuring TakeRandom does not select duplicate items in a full-size draw.


___

## **CodeAnt-AI Description**
Speed up random item selection while preserving predictable selection behavior

### What Changed
- `TakeRandom` selects random items without duplicates using a partial shuffle, avoiding repeated removals as the requested count grows
- Requests for zero or negative counts return an empty sequence without reading the source
- Requests larger than the source return all items; full-size selections avoid an unnecessary extra copy
- Selection behavior and edge cases are covered by regression tests

### Impact
`✅ Faster large random selections`
`✅ Lower allocation for full-source selections`
`✅ Predictable empty results for non-positive counts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved random selection to consistently return unique items.
  * Negative or zero selection counts now return an empty result without errors.
  * Requests larger than the available collection are safely capped.

* **Documentation**
  * Added release documentation describing the updated random selection behavior.

* **Tests**
  * Added coverage for non-positive counts and duplicate prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
