### PR TITLE
test(common): De-flake ToSafeFileName perf test wall-clock bound

### DIFF
--- a/tests/Common.Tests/IO/PathUtilsTests.cs
+++ b/tests/Common.Tests/IO/PathUtilsTests.cs
@@ -376,10 +376,11 @@ public class PathUtilsTests
         result.Length.Should().Be(longInput.Length);
         result.Should().NotContainAny(Path.GetInvalidFileNameChars().Select(c => c.ToString()));
 
-        // Performance assertion - should process in a reasonable time
-        // Processing 100k characters should be fast on modern hardware
-        // NOTE: This was increased to 100ms due to the increased time it takes to run tests with coverage
-        stopwatch.ElapsedMilliseconds.Should().BeLessThan(100, "processing a 100K string should be reasonably fast");
+        // Performance assertion - guards against pathological complexity regressions (e.g. accidental O(n²)),
+        // not micro-performance. The generous bound keeps the test stable on loaded shared CI runners,
+        // where tight wall-clock assertions flake (see #267); an O(n²) regression on 100K characters
+        // would exceed this bound by orders of magnitude.
+        stopwatch.ElapsedMilliseconds.Should().BeLessThan(1000, "processing a 100K string should not exhibit pathological complexity");
     }
 
     [Fact]


### PR DESCRIPTION
## **User description**
## Describe your changes

### Summary

Implements #267 — the `ToSafeFileName_should_have_acceptable_performance_with_very_long_string` test asserted a hard 100ms wall-clock bound, which intermittently fails on loaded shared GitHub runners (observed on PR #265 for a commit that changed no code). This applies the issue's recommended option 1: raise the bound to **1 second**.

### Rationale

The test's real intent is guarding against pathological complexity regressions (accidental O(n²) on a 100K-character input) — such a regression would exceed 1s by orders of magnitude, so the regression-catching value is preserved while runner-load noise (observed ~112ms) no longer trips it. The comment above the assertion now documents this intent so the bound isn't tightened back later. Options 2 (relative baseline measurement) and 3 (BenchmarkDotNet) from the issue were declined as disproportionate for this guard — noted here per the issue discussion.

### Change-log

No entry added — test-only reliability fix with no consumer impact.

## Issue ticket number and link

Closes #267

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. — *Test-only change; all 6 ToSafeFileName tests pass on net8.0 + net10.0, full suite 15/15 assemblies green.*
- [x] Do we need to implement analytics? — No.
- [x] Will this be part of a product update? — No; internal test reliability.

## Testing

- Full solution build: 0 warnings, 0 errors.
- Full test suite: 15/15 assemblies pass.
- Targeted: `FullyQualifiedName~ToSafeFileName` — 6/6 pass on both TFMs.

## Summary by Sourcery

Tests:
- Update the ToSafeFileName long-string performance test to use a more generous 1s threshold and document its intent to catch complexity regressions rather than micro-optimizations.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Increased the performance assertion threshold in PathUtilsTests from 100ms to 1000ms to prevent flaky tests on shared CI runners.</li>
<li>Updated the performance test comment to clarify that the assertion is intended to detect pathological complexity regressions rather than micro-performance issues.</li>
</ul></div>


___

## **CodeAnt-AI Description**
Stabilize the long-filename performance test on shared CI runners

### What Changed
- The 100K-character filename test now allows up to one second instead of 100 milliseconds
- The test continues to catch severe performance regressions while avoiding failures caused by temporary CI runner load
- The performance requirement is documented as a safeguard against inefficient processing rather than minor timing changes

### Impact
`✅ Fewer flaky CI test failures`
`✅ Continued detection of pathological filename-processing slowdowns`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Relaxed the allowable runtime for the long-string safe filename performance test.
  * Clarified that the test detects problematic complexity rather than measuring precise performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->