### PR TITLE
test(apps): Strengthen ActionHandlerManagerTests result assertions

### DIFF
--- a/tests/Common.Apps/Apps.Model.Tests/ActionHandlerManagerTests.cs
+++ b/tests/Common.Apps/Apps.Model.Tests/ActionHandlerManagerTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Ploch.Common.Apps.Model;
 
 namespace Ploch.Common.Apps.Model.Tests;
@@ -5,7 +6,7 @@ namespace Ploch.Common.Apps.Model.Tests;
 public class ActionHandlerManagerTests
 {
     [Fact]
-    public async Task ExecuteAsync_should_return_success_when_handler_succeeds()
+    public async Task ExecuteAsync_should_return_success_with_handler_execution_id_when_handler_succeeds()
     {
         var handler = new SuccessHandler();
         var manager = new ActionHandlerManager<TestDescriptor, TestActionInfo, SuccessHandler>([handler]);
@@ -13,11 +14,18 @@ public class ActionHandlerManagerTests
 
         var result = await manager.ExecuteAsync(actionInfo, TestContext.Current.CancellationToken);
 
-        Assert.True(result.IsSuccess);
+        result.IsSuccess.Should().BeTrue();
+        result.ExecutionId.ActionInfo.Should().BeSameAs(actionInfo);
+        result.ExecutionId.HandlerType.Should().Be<SuccessHandler>();
+        result.Errors.Should().BeNull();
+
+        var handlerResult = result.HandlerResults.Should().ContainSingle().Subject;
+        handlerResult.IsSuccess.Should().BeTrue();
+        handlerResult.ExecutionId.Should().BeSameAs(result.ExecutionId);
     }
 
     [Fact]
-    public async Task ExecuteAsync_should_return_failure_when_all_handlers_fail()
+    public async Task ExecuteAsync_should_return_failure_with_error_details_when_all_handlers_fail()
     {
         var handler = new FailureHandler();
         var manager = new ActionHandlerManager<TestDescriptor, TestActionInfo, FailureHandler>([handler]);
@@ -25,7 +33,16 @@ public class ActionHandlerManagerTests
 
         var result = await manager.ExecuteAsync(actionInfo, TestContext.Current.CancellationToken);
 
-        Assert.False(result.IsSuccess);
+        result.IsSuccess.Should().BeFalse();
+        result.ExecutionId.ActionInfo.Should().BeSameAs(actionInfo);
+        result.ExecutionId.HandlerType.Should().Be<ActionHandlerManager<TestDescriptor, TestActionInfo, FailureHandler>>();
+        result.Errors.Should().ContainSingle().Which.Message.Should().Be($"All handlers failed to execute {actionInfo}");
+
+        var handlerResult = result.HandlerResults.Should().ContainSingle().Subject;
+        handlerResult.IsSuccess.Should().BeFalse();
+        handlerResult.ExecutionId.ActionInfo.Should().BeSameAs(actionInfo);
+        handlerResult.ExecutionId.HandlerType.Should().Be<FailureHandler>();
+        handlerResult.Errors.Should().ContainSingle().Which.Message.Should().Be("test failure");
     }
 
     private sealed class TestDescriptor : IActionTargetDescriptor

--- a/tests/Common.Apps/Apps.Model.Tests/Ploch.Common.Apps.Model.Tests.csproj
+++ b/tests/Common.Apps/Apps.Model.Tests/Ploch.Common.Apps.Model.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
 
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit.v3" />


### PR DESCRIPTION
## **User description**
## Describe your changes

Strengthens the `ActionHandlerManagerTests` result assertions per #253. Both tests previously asserted only `result.IsSuccess`, which could not detect regressions where success/failure occurs for an unexpected reason.

### Changes

- **Success test** (`ExecuteAsync_should_return_success_with_handler_execution_id_when_handler_succeeds`): now also asserts `ExecutionId.ActionInfo` is the submitted action info, `ExecutionId.HandlerType` is the succeeding handler's type, `Errors` is null, and `HandlerResults` contains exactly the single successful handler result whose `ExecutionId` matches the manager result's.
- **Failure test** (`ExecuteAsync_should_return_failure_with_error_details_when_all_handlers_fail`): now also asserts `ExecutionId.ActionInfo`, `ExecutionId.HandlerType` (the manager's own type, per `ActionHandlerManager.GetExecutionId`), the consolidated `Errors` message ("All handlers failed to execute …"), and the single entry in `HandlerResults` including its failure status, execution id contents, and the "test failure" error message.
- Converted the two tests to FluentAssertions per the repository test standards and added the centrally-versioned `FluentAssertions` package reference to `Ploch.Common.Apps.Model.Tests.csproj` (the project previously used plain xUnit asserts only).
- Test names extended to reflect the strengthened behaviour, keeping the `<Method>_should_<behaviour>` convention.

### Design decisions

- Test-only change — no production code was modified; all asserted members (`ExecutionId`, `Errors`, `HandlerResults`) already exist on `ActionHandlerResult`/`ActionHandlerManagerResult`.
- No change-log entry added, as this is a test-only change with no user-visible impact.

### Testing

- `dotnet build Ploch.Common.slnx` — 0 warnings, 0 errors.
- `dotnet test Ploch.Common.slnx` — full suite green (2,000+ tests across all projects, including 7/7 in `Ploch.Common.Apps.Model.Tests`).

## Issue ticket number and link

Closes #253

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? — N/A
- [ ] Will this be part of a product update? — No, test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strengthen ActionHandlerManager result validation in tests using FluentAssertions.

Build:
- Add centrally-versioned FluentAssertions package reference to the Apps.Model test project.

Tests:
- Expand success and failure ActionHandlerManager tests to assert execution IDs, handler types, error details, and handler result contents using FluentAssertions.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added FluentAssertions dependency to the test project.</li>
<li>Refactored ActionHandlerManagerTests to use FluentAssertions for more descriptive test assertions.</li>
<li>Updated test cases to verify additional result details, including ExecutionId, handler results, and error messages.</li>
</ul></div>


___

## **CodeAnt-AI Description**
Strengthen action handler result validation

### What Changed
- Success tests now verify the returned action details, handler type, absence of errors, and the successful handler result
- Failure tests now verify the consolidated error message, manager and handler execution details, failure status, and individual error message
- Test assertions use FluentAssertions for clearer failure output

### Impact
`✅ Earlier detection of incorrect action results`
`✅ Clearer test failures for execution and error details`
`✅ Verified success and failure result contracts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
