### PR TITLE
chore(serialization): Suppress NU5123 long-path warnings in EDI packages

### DIFF
--- a/change-log/2026-08-18-270-nu5123-longpath-suppression.md
+++ b/change-log/2026-08-18-270-nu5123-longpath-suppression.md
@@ -9,8 +9,10 @@ NuGet pack emitted `NU5123` ("path, name, or both are too long") for the
 `lib/netstandard2.0` `.dll` and `.xml` of
 `Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection` and
 `Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection`. The warning
-is now suppressed via a targeted `<NoWarn>` in those two projects only, with the
-rationale documented in each project file.
+is now suppressed via a targeted, **PR-build-only** `<NoWarn>` in those two projects
+(`Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'"`), with the rationale documented
+in each project file. Master, release, and local packs keep `NU5123` live, so a genuine
+overrun of shipped artefacts would still surface as a warning.
 
 ## Analysis
 

--- a/change-log/2026-08-18-270-nu5123-longpath-suppression.md
+++ b/change-log/2026-08-18-270-nu5123-longpath-suppression.md
@@ -1,0 +1,37 @@
+# chore(serialization): Suppress NU5123 long-path pack warnings for the ExtensionsDependencyInjection packages
+
+- **Issue:** [#270](https://github.com/mrploch/ploch-common/issues/270)
+- **Type:** Internal build change — no consumer-facing impact
+
+## Summary
+
+NuGet pack emitted `NU5123` ("path, name, or both are too long") for the
+`lib/netstandard2.0` `.dll` and `.xml` of
+`Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection` and
+`Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection`. The warning
+is now suppressed via a targeted `<NoWarn>` in those two projects only, with the
+rationale documented in each project file.
+
+## Analysis
+
+`NU5123` fires when the installed path `<package_id>/<version>/<file_path_in_package>`
+reaches 200 characters. Both package ids are 71 characters and the dll/xml file names
+are 75, giving:
+
+| Version shape | Version length | Installed path | NU5123? |
+|---|---|---|---|
+| Stable release (`4.0.0`) | 5 | 172 | No |
+| Master prerelease (`4.0.16-prerelease.gXXXXXXXXXX`) | 29 | 196 | No |
+| PR build (`4.0.17-pr.268.chore-264-webui-plai.gXXXXXXXXXX`) | 46 | 213 | **Yes** |
+
+Only PR-validation builds cross the threshold, because Nerdbank.GitVersioning embeds
+the branch name in the version for non-public-release refs. Those packages are
+ephemeral test artefacts published to GitHub Packages only — the packages shipped to
+consumers (master prereleases and stable releases) never exceed the limit. Renaming
+the packages to shorten paths would be a breaking change (as with the #263 rename)
+and is disproportionate to a warning that never affects shipped artefacts.
+
+## Consumer impact
+
+None. Package ids, file names, and contents are unchanged; only the pack-time warning
+for internal PR builds is suppressed.

--- a/src/Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection.csproj
+++ b/src/Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection.csproj
@@ -2,6 +2,14 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        <!--
+            NU5123 fires when <id>/<version>/<path-in-package> reaches 200 characters. With this 71-character
+            package id, shipped versions stay under the limit (master prerelease e.g. 4.0.16-prerelease.gXXXXXXXXXX
+            = 196 chars; stable 4.0.0 = 172), but PR-validation builds embed the branch name in the NBGV version
+            (e.g. 4.0.17-pr.268.chore-264-webui-plai.gXXXXXXXXXX) and cross the threshold. Those packages are
+            ephemeral test artefacts on GitHub Packages only, so the warning is suppressed. See issue #270.
+        -->
+        <NoWarn>$(NoWarn);NU5123</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Common.Serialization.NewtonsoftJson\Ploch.Common.Serialization.NewtonsoftJson.csproj" />

--- a/src/Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection.csproj
+++ b/src/Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.NewtonsoftJson.ExtensionsDependencyInjection.csproj
@@ -7,9 +7,11 @@
             package id, shipped versions stay under the limit (master prerelease e.g. 4.0.16-prerelease.gXXXXXXXXXX
             = 196 chars; stable 4.0.0 = 172), but PR-validation builds embed the branch name in the NBGV version
             (e.g. 4.0.17-pr.268.chore-264-webui-plai.gXXXXXXXXXX) and cross the threshold. Those packages are
-            ephemeral test artefacts on GitHub Packages only, so the warning is suppressed. See issue #270.
+            ephemeral test artefacts on GitHub Packages only, so the warning is suppressed for PR builds only —
+            master, release, and local packs keep NU5123 live and would surface a genuine overrun of shipped
+            artefacts. See issue #270.
         -->
-        <NoWarn>$(NoWarn);NU5123</NoWarn>
+        <NoWarn Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'">$(NoWarn);NU5123</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Common.Serialization.NewtonsoftJson\Ploch.Common.Serialization.NewtonsoftJson.csproj" />

--- a/src/Common.Serialization.SystemTextJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection.csproj
+++ b/src/Common.Serialization.SystemTextJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection.csproj
@@ -8,9 +8,11 @@
             package id, shipped versions stay under the limit (master prerelease e.g. 4.0.16-prerelease.gXXXXXXXXXX
             = 196 chars; stable 4.0.0 = 172), but PR-validation builds embed the branch name in the NBGV version
             (e.g. 4.0.17-pr.268.chore-264-webui-plai.gXXXXXXXXXX) and cross the threshold. Those packages are
-            ephemeral test artefacts on GitHub Packages only, so the warning is suppressed. See issue #270.
+            ephemeral test artefacts on GitHub Packages only, so the warning is suppressed for PR builds only —
+            master, release, and local packs keep NU5123 live and would surface a genuine overrun of shipped
+            artefacts. See issue #270.
         -->
-        <NoWarn>$(NoWarn);NU5123</NoWarn>
+        <NoWarn Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'">$(NoWarn);NU5123</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Common.DependencyInjection\Ploch.Common.DependencyInjection.csproj" />

--- a/src/Common.Serialization.SystemTextJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection.csproj
+++ b/src/Common.Serialization.SystemTextJson.ExtensionsDependencyInjection/Ploch.Common.Serialization.SystemTextJson.ExtensionsDependencyInjection.csproj
@@ -3,6 +3,14 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Platforms>AnyCPU;x64</Platforms>
+        <!--
+            NU5123 fires when <id>/<version>/<path-in-package> reaches 200 characters. With this 71-character
+            package id, shipped versions stay under the limit (master prerelease e.g. 4.0.16-prerelease.gXXXXXXXXXX
+            = 196 chars; stable 4.0.0 = 172), but PR-validation builds embed the branch name in the NBGV version
+            (e.g. 4.0.17-pr.268.chore-264-webui-plai.gXXXXXXXXXX) and cross the threshold. Those packages are
+            ephemeral test artefacts on GitHub Packages only, so the warning is suppressed. See issue #270.
+        -->
+        <NoWarn>$(NoWarn);NU5123</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Common.DependencyInjection\Ploch.Common.DependencyInjection.csproj" />


### PR DESCRIPTION
## Describe your changes

### Summary

NuGet pack emits **NU5123** ("path, name, or both are too long — your package might not work without long file path support") for the `lib/netstandard2.0` `.dll` and `.xml` of the two `*.ExtensionsDependencyInjection` packages. This PR suppresses the warning with a targeted, **PR-build-only** `<NoWarn>` (`Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'"`) in those two projects, with the rationale documented in each project file, plus a change-log entry.

### Analysis (why suppress, not rename)

NU5123 fires when the installed path `<package_id>/<version>/<file_path_in_package>` reaches **200 characters**. Both package ids are 71 chars and the dll/xml filenames 75:

| Version shape | Version length | Installed path | NU5123? |
|---|---|---|---|
| Stable release (`4.0.0`) | 5 | 172 | No |
| Master prerelease (`4.0.16-prerelease.gXXXXXXXXXX`) | 29 | 196 | No |
| PR build (`4.0.17-pr.268.chore-264-webui-plai.gXXXXXXXXXX`) | 46 | **213** | **Yes** |

Only **PR-validation builds** cross the threshold, because `build-dotnet.yml` embeds the (20-char-truncated) branch name in the NBGV version for PR refs. PR packages are ephemeral test artefacts published to GitHub Packages only — **the packages shipped to consumers never exceed the limit**. Renaming the packages would be a breaking change (same treatment as the #263 rename) and is disproportionate.

### Changes

- `<NoWarn Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'">$(NoWarn);NU5123</NoWarn>` with an explanatory comment in the `SystemTextJson.ExtensionsDependencyInjection` and `NewtonsoftJson.ExtensionsDependencyInjection` csproj files. **Scoped to PR builds only** (refined per Copilot review): master, release, and local packs keep NU5123 live, so a genuine overrun of shipped artefacts (master prerelease sits at 196/200) would still surface.
- Change-log entry `change-log/2026-08-18-270-nu5123-longpath-suppression.md`.

### Design Decisions

- **Per-project scope** (not `.editorconfig`/`Directory.Build.props`): repo convention reserves global disables for warnings in 3+ files; this affects exactly the two 71-char-id packages.
- **Env-var condition over NBGV `PublicRelease`**: `PublicRelease` is computed by NBGV targets during execution, but `NoWarn` evaluates at project-evaluation time — the GitHub Actions env var is available then; verified under both contexts.

### Testing

- **Empirical repro:** scratch project with identical geometry (71-char id, 46-char PR-style version, `lib/netstandard2.0`) reproduces NU5123 on SDK 10.0.400 and confirms `NoWarn` suppresses it.
- Conditional verified by `dotnet msbuild -getProperty:NoWarn`: `NU5123` present only with `GITHUB_EVENT_NAME=pull_request`.
- Full `Ploch.Common.slnx` build: **0 warnings, 0 errors**. Both EDI test projects pass (3/3).
- End-to-end proof: this PR's own CI build uses a PR-style version crossing the threshold, so the `build` check must produce **zero NU5123 annotations**.

### Review notes

Second-opinion review performed by a local independent code-review agent (verdict: APPROVED, math independently re-verified) **substituting for the Codex MCP**, which rejects all models on this account (known environment limitation, same as PRs #259–#265). All 3 Copilot review threads addressed: 2 accepted (conditional scoping, commit 9a8f17f), 1 false positive (default branch is `master`, not `main`).

Follow-up filed during research: #273 (unused FluentAssertions references in the NewtonsoftJson EDI package).

## Issue ticket number and link

Closes #270

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. *(Build-config-only change — verified via empirical pack repro + property evaluation + full-solution build + existing tests.)*
- [x] Do we need to implement analytics? *(No.)*
- [x] Will this be part of a product update? *(Internal build hygiene; no consumer-facing impact.)*