### PR TITLE
build(release): Stop excluding TestingSupport packages from the NuGet.org publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
             echo "::error::No .nupkg files were produced by the build."
             exit 1
           fi
-          echo "$PKGS" | while read pkg; do
+          echo "$PKGS" | while IFS= read -r pkg; do
             echo "Publishing $pkg"
             dotnet nuget push "$pkg" --source https://api.nuget.org/v3/index.json --skip-duplicate -k "$NUGET_API_KEY"
           done
@@ -183,7 +183,7 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
-          find . -name '*.snupkg' -not -path './tests/*' | while read pkg; do
+          find . -name '*.snupkg' -not -path './tests/*' | while IFS= read -r pkg; do
             echo "Publishing symbols $pkg"
             dotnet nuget push "$pkg" --source https://api.nuget.org/v3/index.json --skip-duplicate -k "$NUGET_API_KEY"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,12 +157,18 @@ jobs:
           fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
+      # Package selection excludes ./tests/ structurally rather than matching on the name
+      # "Test". A previous `-not -path '*/Test*'` filter also matched ./src/TestingSupport*,
+      # because find -path matches the whole path and * spans /, so every TestingSupport
+      # library was silently dropped from the NuGet.org publish - see issue #278. The one
+      # package that genuinely must not ship is tests/TestAssemblies/Common.Tests.TestTypes,
+      # which is packable only because its name ends in TestTypes rather than Tests.
       - name: Publish NuGet packages to NuGet.org
         if: success()
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
-          PKGS=$(find . -name '*.nupkg' -not -path '*/test*' -not -path '*/Test*')
+          PKGS=$(find . -name '*.nupkg' -not -path './tests/*')
           if [ -z "$PKGS" ]; then
             echo "::error::No .nupkg files were produced by the build."
             exit 1
@@ -177,7 +183,7 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
-          find . -name '*.snupkg' -not -path '*/test*' -not -path '*/Test*' | while read pkg; do
+          find . -name '*.snupkg' -not -path './tests/*' | while read pkg; do
             echo "Publishing symbols $pkg"
             dotnet nuget push "$pkg" --source https://api.nuget.org/v3/index.json --skip-duplicate -k "$NUGET_API_KEY"
           done

--- a/change-log/2026-08-19-278-release-filter-excludes-testingsupport.md
+++ b/change-log/2026-08-19-278-release-filter-excludes-testingsupport.md
@@ -1,0 +1,31 @@
+## Release pipeline: TestingSupport packages are published to NuGet.org again
+
+### Fixed
+
+- **The release workflow no longer silently drops every `TestingSupport.*` package.** `.github/workflows/release.yml` selected packages to push with `find . -name '*.nupkg' -not -path '*/test*' -not -path '*/Test*'`. The intent was to skip test projects, but `find -path` matches the whole path and `*` spans `/`, so `*/Test*` also matched `./src/TestingSupport*/bin/Release/*.nupkg`. Every `TestingSupport.*` library was therefore excluded from the NuGet.org publish, with no error and no failed check — the only symptom was a package quietly not appearing. Both the `.nupkg` and `.snupkg` selection now exclude `./tests/*` structurally instead.
+
+### Impact on the next release
+
+The next release publishes three packages that previous releases skipped:
+
+| Package | Previously on NuGet.org | Next release |
+|---|---|---|
+| `Ploch.TestingSupport` | 2.0.1 | current version |
+| `Ploch.TestingSupport.FluentAssertions` | 2.0.1 | current version |
+| `Ploch.TestingSupport.MockConsoleApp` | never published | first publish |
+
+`Ploch.TestingSupport` and `Ploch.TestingSupport.FluentAssertions` had been frozen at **2.0.1** on NuGet.org across several releases while the repository moved on to 4.0.x. Consumers pinned to those versions will see a two-major jump become available.
+
+Verified against a real `dotnet build -c Release` of the solution: the old filter selected 15 packages, the new one selects 18, and the three added are exactly the `TestingSupport.*` libraries above. `tests/TestAssemblies/Common.Tests.TestTypes` — which is packable only because its project name ends in `TestTypes` rather than `Tests`, and which must not ship — remains excluded.
+
+### Notes
+
+The corrected filter deliberately expresses the exclusion structurally (`./tests/*`) rather than by matching the word `Test` anywhere in a path, and carries a comment recording the original defect so it is not reintroduced.
+
+Two related problems were found while fixing this and are tracked separately rather than folded in: the GitHub Packages publish in `build-dotnet.yml` applies no filter at all and ships test scaffolding to that feed (#279), and `Ploch.TestingSupport.XUnit3` / `.AutoMoq` evaluate to `IsPackable=false` because of an xUnit v3 props file and produce no package at all, so they cannot be published by any pipeline (#280).
+
+### Refs
+
+- #278 (release workflow filter excludes all TestingSupport packages from NuGet.org)
+- Follow-ups: #279, #280
+- Unblocks the NuGet.org publish of `Ploch.TestingSupport.MockConsoleApp` added in #275 / #276


### PR DESCRIPTION
## **User description**
## Describe your changes

`.github/workflows/release.yml` selected packages to push to NuGet.org with:

```bash
find . -name '*.nupkg' -not -path '*/test*' -not -path '*/Test*'
```

The intent is "skip test projects". But `find -path` matches the **whole path** and `*` spans `/`, so `*/Test*` also matches `./src/TestingSupport*/bin/Release/*.nupkg`. Every `TestingSupport.*` library has therefore been silently excluded from the NuGet.org publish.

The failure mode is invisible: a filtered-out package simply does not appear — no error, no failed check, no warning. That is why it survived several releases.

### Impact

| Package | On NuGet.org today | Repo version |
|---|---|---|
| `Ploch.Common` | 3.0.0 | 4.0.x |
| `Ploch.TestingSupport` | **2.0.1** | 4.0.x |
| `Ploch.TestingSupport.FluentAssertions` | **2.0.1** | 4.0.x |
| `Ploch.TestingSupport.MockConsoleApp` | **never published** | 4.0.x |

Two shipped libraries have been frozen two major versions behind.

## Changes

- `release.yml` — both the `.nupkg` (line 165) and `.snupkg` (line 180) selections now exclude `./tests/*` structurally instead of matching the word `Test` anywhere in a path.
- A comment above the publish step records the original defect so the name-matching form is not reintroduced.
- Change-log entry describing the fix and, importantly, what the next release will now publish.

## Design Decisions

**Structural exclusion (`./tests/*`), not a positive allowlist.** `find ./src -name '*.nupkg'` was considered and rejected: it would fail the same way in reverse, silently dropping any future packable project that lives outside `src/`. Excluding `./tests/*` preserves the original intent while making the pattern mean what it says.

**The filter could not simply be deleted.** It does catch one genuine case: `tests/TestAssemblies/Common.Tests.TestTypes` is packable, because `Directory.Build.props` derives `IsTestProject` from `MSBuildProjectName.EndsWith('Tests')` and that project ends in `TestTypes`, not `Tests`. It produces a `.nupkg` that must not ship.

**Two related defects were deliberately kept out of this PR** so the release-pipeline fix stays small and reviewable:

- **#279** — `build-dotnet.yml` pushes `./**/*.nupkg` to GitHub Packages with no filter at all, so test scaffolding is published to that feed on every build.
- **#280** — `Ploch.TestingSupport.XUnit3` and `.AutoMoq` evaluate to `IsPackable=false` (xUnit v3's `xunit.v3.core.mtp-v1.props` sets `TestProject=true`, which the SDK treats as non-packable), so they produce no package for any pipeline to publish. Independent root cause; does not block this fix.

## Testing

Verified against a real `dotnet build ./Ploch.Common.slnx -c Release` — the exact command the release workflow runs — rather than reasoning about the glob:

| Check | Result |
|---|---|
| Old filter | selects **15** packages |
| New filter | selects **18** packages |
| Newly included | exactly `Ploch.TestingSupport`, `Ploch.TestingSupport.FluentAssertions`, `Ploch.TestingSupport.MockConsoleApp` |
| Still excluded | exactly `tests/TestAssemblies/Common.Tests.TestTypes` (correct) |
| Solution build | 0 warnings, 0 errors |
| Workflow YAML | parses; 23 steps; both publish steps intact |

The workflow itself cannot be exercised without cutting a real release, which is irreversible on NuGet.org — so verification is against the exact selection command and build output it uses.

## Review round 1

Codacy flagged `read` without `-r` in the `.snupkg` publish loop (SC2162) — backslashes would be interpreted as escape sequences. Accepted and fixed in `b0d4af6`, using `while IFS= read -r pkg` so whitespace is not trimmed either.

Applied to **both** loops, not just the flagged one: Codacy could only see the `.snupkg` loop because that was the line this PR touched, while the `.nupkg` loop ten lines above had the identical defect and fell outside the diff. Fixing one and leaving the other would have left the bug in place behind a false impression it was handled.

Re-verified after the change: YAML parses with 23 steps and both publish steps intact, and the loops enumerate the same sets against a real `-c Release` build — 18 `.nupkg`, 17 `.snupkg`.

## Breaking Changes

None to any API. But note for whoever cuts the next release: it will publish `Ploch.TestingSupport` and `Ploch.TestingSupport.FluentAssertions` at 4.0.x — a two-major jump from the 2.0.1 currently public — and first-publish `Ploch.TestingSupport.MockConsoleApp`. That is the intended outcome, and it is irreversible once pushed, so it should be a deliberate decision at release time rather than a surprise.

## Related

- Closes #278
- Follow-ups filed: #279, #280
- Unblocks the NuGet.org publish of `Ploch.TestingSupport.MockConsoleApp` added in #275 / #276

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. — verified against real Release build output; the publish step itself cannot be exercised without an irreversible release
- [ ] Do we need to implement analytics? — n/a
- [x] Will this be part of a product update? If yes, please write one phrase about this update. — `Ploch.TestingSupport`, `.FluentAssertions` and `.MockConsoleApp` will be published to NuGet.org again from the next release, after being silently excluded for several releases.

## Summary by Sourcery

Publish TestingSupport packages to NuGet.org while retaining structural exclusion of test artifacts.

Bug Fixes:
- Correct the NuGet.org release filters so TestingSupport packages are published instead of being silently excluded by path-name matching.
- Continue excluding packable test artifacts under the tests directory from regular and symbol package publishing.

Enhancements:
- Document the release-filter defect and its impact on the next NuGet.org release.

Tests:
- Verify package selection against a Release build, confirming the three intended TestingSupport packages are newly included while the test artifact remains excluded.


___

## **CodeAnt-AI Description**
Publish TestingSupport packages to NuGet.org

### What Changed
- The release pipeline now publishes `TestingSupport.*` packages instead of silently excluding them
- Test packages under `./tests/` remain excluded from both regular and symbol package publishing
- The next release will include current versions of `Ploch.TestingSupport`, `Ploch.TestingSupport.FluentAssertions`, and the first NuGet.org release of `Ploch.TestingSupport.MockConsoleApp`

### Impact
`✅ Current TestingSupport versions available on NuGet.org`
`✅ First NuGet.org release for MockConsoleApp`
`✅ Test-only packages remain out of production releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected release filtering so `TestingSupport` packages are published as expected.
  * Continued excluding test packages from standard and symbol package releases.
* **Documentation**
  * Added a changelog entry describing the release-filter correction, affected packages, verification results, and related follow-up items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
